### PR TITLE
Improve performance of movements list

### DIFF
--- a/src/components/JumpNavigation/JumpNavigation.js
+++ b/src/components/JumpNavigation/JumpNavigation.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Item from './Item';
 
@@ -11,12 +11,16 @@ const Wrapper = styled.div`
   }
 `;
 
-const JumpNavigation = () => (
-  <Wrapper>
-    <Item href="/" icon="home" label="Startseite"/>
-    <Item href="/departure/new" icon="flight_takeoff" label="Abflug erfassen"/>
-    <Item href="/arrival/new" icon="flight_land" label="Ankunft erfassen"/>
-  </Wrapper>
-);
+class JumpNavigation extends React.PureComponent {
+  render() {
+    return (
+      <Wrapper>
+        <Item href="/" icon="home" label="Startseite"/>
+        <Item href="/departure/new" icon="flight_takeoff" label="Abflug erfassen"/>
+        <Item href="/arrival/new" icon="flight_land" label="Ankunft erfassen"/>
+      </Wrapper>
+    );
+  }
+}
 
 export default JumpNavigation;

--- a/src/components/MaterialIcon/MaterialIcon.js
+++ b/src/components/MaterialIcon/MaterialIcon.js
@@ -31,9 +31,11 @@ const I = styled.i`
   vertical-align: middle;
 `;
 
-const MaterialIcon = props => (
-  <I className={props.className}>{props.icon}</I>
-);
+class MaterialIcon extends React.PureComponent {
+  render() {
+    return <I className={this.props.className}>{this.props.icon}</I>;
+  }
+}
 
 MaterialIcon.propTypes = {
   icon: React.PropTypes.string.isRequired,

--- a/src/components/MovementList/Movement.js
+++ b/src/components/MovementList/Movement.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from 'react';
+import React, {PropTypes} from 'react';
 import MaterialIcon from '../MaterialIcon';
 import styled from 'styled-components';
 import dates from '../../util/dates';
@@ -73,25 +73,15 @@ const ActionLabel = styled.span`
   }
 `;
 
-const Action = props => (
-  <StyledAction onClick={props.onClick} className={props.className}>
-    <MaterialIcon icon={props.icon}/><ActionLabel>&nbsp;{props.label}</ActionLabel>
-  </StyledAction>
-);
-
-const handleActionClick = (onAction, data, e) => {
-  e.stopPropagation(); // prevent call of onClick handler
-  if (typeof onAction === 'function') {
-    onAction(data);
+class Action extends React.PureComponent {
+  render() {
+    return (
+      <StyledAction onClick={this.props.onClick} className={this.props.className}>
+        <MaterialIcon icon={this.props.icon}/><ActionLabel>&nbsp;{this.props.label}</ActionLabel>
+      </StyledAction>
+    );
   }
-};
-
-const handleDeleteClick = (onDelete, data, e) => {
-  e.stopPropagation(); // prevent call of onClick handler
-  if (typeof onDelete === 'function') {
-    onDelete(data);
-  }
-};
+}
 
 const getLocation = data => {
   if (data.location.toUpperCase() === __CONF__.aerodrome.ICAO) {
@@ -103,40 +93,71 @@ const getLocation = data => {
   return data.location;
 };
 
-const Movement = props =>{
-  const date = props.timeWithDate === true
-    ? dates.formatDate(props.data.date)
-    : null;
-  const time = dates.formatTime(props.data.date, props.data.time);
+class Movement extends React.PureComponent {
 
-  return (
-    <Wrapper onClick={props.onClick} locked={props.locked}>
-      <Column className="immatriculation">{props.data.immatriculation}</Column>
-      <Column className="pilot">{props.data.lastname}</Column>
-      <Column className="datetime">
-        {date && <Date className="date">{date}</Date>}
-        <div className="time">{time}</div>
-      </Column>
-      <Column className="location">{getLocation(props.data)}</Column>
-      <ActionColumn className="action">
-        <Action
-          label={props.actionLabel}
-          icon={props.actionIcon}
-          onClick={handleActionClick.bind(null, props.onAction, props.data)}
-        />
-      </ActionColumn>
-      <ActionColumn className="delete">
-        {!props.locked && (
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleActionClick = this.handleActionClick.bind(this);
+    this.handleDeleteClick = this.handleDeleteClick.bind(this);
+  }
+
+  render() {
+    const props = this.props;
+    const date = props.timeWithDate === true
+      ? dates.formatDate(props.data.date)
+      : null;
+    const time = dates.formatTime(props.data.date, props.data.time);
+
+    return (
+      <Wrapper onClick={this.handleClick} locked={props.locked}>
+        <Column className="immatriculation">{props.data.immatriculation}</Column>
+        <Column className="pilot">{props.data.lastname}</Column>
+        <Column className="datetime">
+          {date && <Date className="date">{date}</Date>}
+          <div className="time">{time}</div>
+        </Column>
+        <Column className="location">{getLocation(props.data)}</Column>
+        <ActionColumn className="action">
           <Action
-            label="Löschen"
-            icon="delete"
-            onClick={handleDeleteClick.bind(null, props.onDelete, props.data)}
+            label={props.actionLabel}
+            icon={props.actionIcon}
+            onClick={this.handleActionClick}
           />
-        )}
-      </ActionColumn>
-    </Wrapper>
-  );
-};
+        </ActionColumn>
+        <ActionColumn className="delete">
+          {!props.locked && (
+            <Action
+              label="Löschen"
+              icon="delete"
+              onClick={this.handleDeleteClick}
+            />
+          )}
+        </ActionColumn>
+      </Wrapper>
+    );
+  }
+
+  handleClick() {
+    if (typeof this.props.onClick === 'function') {
+      this.props.onClick(this.props.data.key);
+    }
+  }
+
+  handleActionClick(e) {
+    e.stopPropagation(); // prevent call of onClick handler
+    if (typeof this.props.onAction === 'function') {
+      this.props.onAction(this.props.data.key);
+    }
+  }
+
+  handleDeleteClick(e) {
+    e.stopPropagation(); // prevent call of onClick handler
+    if (typeof this.props.onDelete === 'function') {
+      this.props.onDelete(this.props.data);
+    }
+  }
+}
 
 Movement.propTypes = {
   data: PropTypes.object,

--- a/src/components/MovementList/MovementGroup.js
+++ b/src/components/MovementList/MovementGroup.js
@@ -20,32 +20,45 @@ const ItemsContainer = styled.div`
   overflow: hidden;
 `;
 
-const MovementGroup = props => (
-  <GroupWrapper>
-    <GroupLabel>{props.label}</GroupLabel>
-    <ItemsContainer>
-      {props.items.map((item, index) => {
-        return (
-          <Movement
-            key={index}
-            data={item}
-            onClick={props.onClick.bind(null, item)}
-            timeWithDate={props.timeWithDate}
-            onAction={props.onAction}
-            actionIcon={props.actionIcon}
-            actionLabel={props.actionLabel}
-            onDelete={props.onDelete}
-            locked={isLocked(item, props.lockDate)}
-          />
-        );
-      })}
-    </ItemsContainer>
-  </GroupWrapper>
-);
+class MovementGroup extends React.PureComponent {
+
+  render() {
+    const props = this.props;
+    const items = props.items.filter(props.predicate);
+
+    if (items.length === 0) {
+      return null;
+    }
+
+    return (
+      <GroupWrapper>
+        <GroupLabel>{props.label}</GroupLabel>
+        <ItemsContainer>
+          {items.map(item => {
+            return (
+              <Movement
+                key={item.key}
+                data={item}
+                onClick={props.onClick}
+                timeWithDate={props.timeWithDate}
+                onAction={props.onAction}
+                actionIcon={props.actionIcon}
+                actionLabel={props.actionLabel}
+                onDelete={props.onDelete}
+                locked={isLocked(item, props.lockDate)}
+              />
+            );
+          })}
+        </ItemsContainer>
+      </GroupWrapper>
+    );
+  }
+}
 
 MovementGroup.propTypes = {
   label: PropTypes.string,
   items: PropTypes.array,
+  predicate: PropTypes.func,
   onClick: PropTypes.func,
   timeWithDate: PropTypes.bool,
   onAction: PropTypes.func,

--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -6,13 +6,27 @@ import LoadingFailureInfo from './LoadingFailureInfo';
 import MovementDeleteConfirmationDialog from '../MovementDeleteConfirmationDialog';
 import { AutoLoad } from '../../util/AutoLoad';
 
+const afterTodayPredicate = Predicates.newerThanSameDay();
+const todayPredicate = Predicates.sameDay();
+const yesterdayPredicate = Predicates.dayBefore();
+const thisMonthPredicate = Predicates.and(
+  Predicates.sameMonth(),
+  Predicates.olderThanSameDay(),
+  Predicates.not(Predicates.dayBefore())
+);
+const olderPredicate = Predicates.and(
+  Predicates.olderThanSameMonth(),
+  Predicates.not(Predicates.dayBefore())
+);
+
 /**
+ * future
  * today
  * yesterday
  * this month
  * older
  */
-class MovementList extends Component {
+class MovementList extends React.PureComponent {
 
   componentWillMount() {
     if (this.props.items.length === 0) {
@@ -25,21 +39,6 @@ class MovementList extends Component {
       return <LoadingInfo/>;
     }
 
-    const movements = this.props.items;
-
-    const movementsAfterToday = movements.filter(Predicates.newerThanSameDay());
-    const movementsOfToday = movements.filter(Predicates.sameDay());
-    const movementsOfYesterday = movements.filter(Predicates.dayBefore());
-    const movementsOfThisMonth = movements.filter(Predicates.and(
-      Predicates.sameMonth(),
-      Predicates.olderThanSameDay(),
-      Predicates.not(Predicates.dayBefore())
-    ));
-    const olderMovements = movements.filter(Predicates.and(
-      Predicates.olderThanSameMonth(),
-      Predicates.not(Predicates.dayBefore())
-    ));
-
     const confirmationDialog = this.props.deleteConfirmation ?
       (<MovementDeleteConfirmationDialog
         item={this.props.deleteConfirmation}
@@ -49,9 +48,10 @@ class MovementList extends Component {
 
     return (
       <div>
-        {movementsAfterToday.length > 0 && <MovementGroup
+        <MovementGroup
           label="Ab morgen"
-          items={movementsAfterToday}
+          items={this.props.items}
+          predicate={afterTodayPredicate}
           onClick={this.props.onClick}
           timeWithDate={true}
           onAction={this.props.onAction}
@@ -59,10 +59,11 @@ class MovementList extends Component {
           actionLabel={this.props.actionLabel}
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
-        />}
-        {movementsOfToday.length > 0 && <MovementGroup
+        />
+        <MovementGroup
           label="Heute"
-          items={movementsOfToday}
+          items={this.props.items}
+          predicate={todayPredicate}
           onClick={this.props.onClick}
           timeWithDate={false}
           onAction={this.props.onAction}
@@ -70,10 +71,11 @@ class MovementList extends Component {
           actionLabel={this.props.actionLabel}
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
-        />}
-        {movementsOfYesterday.length > 0 && <MovementGroup
+        />
+        <MovementGroup
           label="Gestern"
-          items={movementsOfYesterday}
+          items={this.props.items}
+          predicate={yesterdayPredicate}
           onClick={this.props.onClick}
           timeWithDate={false}
           onAction={this.props.onAction}
@@ -81,27 +83,29 @@ class MovementList extends Component {
           actionLabel={this.props.actionLabel}
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
-        />}
-        {movementsOfThisMonth.length > 0 && <MovementGroup
+        />
+        <MovementGroup
           label="Dieser Monat"
-          items={movementsOfThisMonth}
+          items={this.props.items}
+          predicate={thisMonthPredicate}
           onClick={this.props.onClick}
           onAction={this.props.onAction}
           actionIcon={this.props.actionIcon}
           actionLabel={this.props.actionLabel}
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
-        />}
-        {olderMovements.length > 0 && <MovementGroup
+        />
+        <MovementGroup
           label="Älter"
-          items={olderMovements}
+          items={this.props.items}
+          predicate={olderPredicate}
           onClick={this.props.onClick}
           onAction={this.props.onAction}
           actionIcon={this.props.actionIcon}
           actionLabel={this.props.actionLabel}
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
-        />}
+        />
         {this.props.loading && <LoadingInfo/>}
         {this.props.loadingFailed && <LoadingFailureInfo/>}
         {confirmationDialog}

--- a/src/components/MovementsPage/MovementsPage.js
+++ b/src/components/MovementsPage/MovementsPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Content from './Content';
-import MovementList from '../MovementList';
+import DepartureList from '../../containers/DepartureListContainer';
+import ArrivalList from '../../containers/ArrivalListContainer';
 import TabPanel from '../TabPanel';
 import JumpNavigation from '../JumpNavigation';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
@@ -11,67 +12,13 @@ class MovementsPage extends Component {
     this.props.loadLockDate();
   }
 
-  departuresListClick(item) {
-    this.props.showDepartureWizard(item.key);
-  }
-
-  arrivalsListClick(item) {
-    this.props.showArrivalWizard(item.key);
-  }
-
-  departuresActionClick(item) {
-    this.props.createArrivalFromDeparture(item.key);
-  }
-
-  arrivalsActionClick(item) {
-    this.props.createDepartureFromArrival(item.key);
-  }
-
   render() {
-    const departuresList = (
-      <MovementList
-        key="departures"
-        className="departures"
-        loadItems={this.props.loadDepartures}
-        items={this.props.movements.departures.data.array}
-        loading={this.props.movements.departures.loading}
-        loadingFailed={this.props.movements.departures.loadingFailed}
-        onClick={this.departuresListClick.bind(this)}
-        onAction={this.departuresActionClick.bind(this)}
-        actionIcon="flight_land"
-        actionLabel="Ankunft erfassen"
-        lockDate={this.props.lockDate}
-        deleteConfirmation={this.props.deleteConfirmation}
-        deleteItem={this.props.deleteDeparture}
-        hideDeleteConfirmationDialog={this.props.hideDeleteConfirmationDialog}
-        showDeleteConfirmationDialog={this.props.showDeleteConfirmationDialog}
-      />
-    );
-    const arrivalsList = (
-      <MovementList
-        key="arrivals"
-        className="arrivals"
-        loadItems={this.props.loadArrivals}
-        items={this.props.movements.arrivals.data.array}
-        loading={this.props.movements.arrivals.loading}
-        loadingFailed={this.props.movements.arrivals.loadingFailed}
-        onClick={this.arrivalsListClick.bind(this)}
-        onAction={this.arrivalsActionClick.bind(this)}
-        actionIcon="flight_takeoff"
-        actionLabel="Abflug erfassen"
-        lockDate={this.props.lockDate}
-        deleteConfirmation={this.props.deleteConfirmation}
-        deleteItem={this.props.deleteArrival}
-        hideDeleteConfirmationDialog={this.props.hideDeleteConfirmationDialog}
-        showDeleteConfirmationDialog={this.props.showDeleteConfirmationDialog}
-      />
-    );
     const tabs = [{
       label: 'Abflüge',
-      component: departuresList,
+      component: <DepartureList/>,
     }, {
       label: 'Ankünfte',
-      component: arrivalsList,
+      component: <ArrivalList/>,
     }];
     return (
       <VerticalHeaderLayout>
@@ -85,20 +32,7 @@ class MovementsPage extends Component {
 }
 
 MovementsPage.propTypes = {
-  movements: React.PropTypes.object.isRequired,
-  loadDepartures: React.PropTypes.func.isRequired,
-  deleteDeparture: React.PropTypes.func.isRequired,
-  loadArrivals: React.PropTypes.func.isRequired,
-  deleteArrival: React.PropTypes.func.isRequired,
-  lockDate: React.PropTypes.object.isRequired,
   loadLockDate: React.PropTypes.func.isRequired,
-  deleteConfirmation: React.PropTypes.object,
-  showDeleteConfirmationDialog: React.PropTypes.func.isRequired,
-  hideDeleteConfirmationDialog: React.PropTypes.func.isRequired,
-  createDepartureFromArrival: React.PropTypes.func.isRequired,
-  createArrivalFromDeparture: React.PropTypes.func.isRequired,
-  showDepartureWizard: React.PropTypes.func.isRequired,
-  showArrivalWizard: React.PropTypes.func.isRequired,
 };
 
 export default MovementsPage;

--- a/src/containers/ArrivalListContainer.js
+++ b/src/containers/ArrivalListContainer.js
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { loadArrivals, deleteArrival } from '../modules/movements/arrivals';
+import {
+  showDeleteConfirmationDialog,
+  hideDeleteConfirmationDialog,
+  showArrivalWizard,
+  createDepartureFromArrival,
+} from '../modules/ui/movements';
+
+import MovementList from '../components/MovementList';
+
+const mapStateToProps = state => {
+  return {
+    items: state.movements.arrivals.data.array,
+    loading: state.movements.arrivals.loading,
+    loadingFailed: state.movements.arrivals.loadingFailed,
+    lockDate: state.settings.lockDate,
+    deleteConfirmation: state.ui.movements.deleteConfirmation,
+    actionIcon: 'flight_takeoff',
+    actionLabel: 'Abflug'
+  };
+};
+
+const mapActionCreators = {
+  showDeleteConfirmationDialog,
+  hideDeleteConfirmationDialog,
+  loadItems: loadArrivals,
+  deleteItem: deleteArrival,
+  onClick: showArrivalWizard,
+  onAction: createDepartureFromArrival
+};
+
+export default connect(mapStateToProps, mapActionCreators)(MovementList);

--- a/src/containers/DepartureListContainer.js
+++ b/src/containers/DepartureListContainer.js
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { loadDepartures, deleteDeparture } from '../modules/movements/departures';
+import {
+  showDeleteConfirmationDialog,
+  hideDeleteConfirmationDialog,
+  showDepartureWizard,
+  createArrivalFromDeparture
+} from '../modules/ui/movements';
+
+import MovementList from '../components/MovementList';
+
+const mapStateToProps = state => {
+  return {
+    items: state.movements.departures.data.array,
+    loading: state.movements.departures.loading,
+    loadingFailed: state.movements.departures.loadingFailed,
+    lockDate: state.settings.lockDate,
+    deleteConfirmation: state.ui.movements.deleteConfirmation,
+    actionIcon: 'flight_land',
+    actionLabel: 'Ankunft erfassen'
+  };
+};
+
+const mapActionCreators = {
+  showDeleteConfirmationDialog,
+  hideDeleteConfirmationDialog,
+  loadItems: loadDepartures,
+  deleteItem: deleteDeparture,
+  onClick: showDepartureWizard,
+  onAction: createArrivalFromDeparture
+};
+
+export default connect(mapStateToProps, mapActionCreators)(MovementList);

--- a/src/containers/MovementsPageContainer.js
+++ b/src/containers/MovementsPageContainer.js
@@ -1,38 +1,16 @@
 import { connect } from 'react-redux';
-import { loadDepartures, deleteDeparture } from '../modules/movements/departures';
-import { loadArrivals, deleteArrival } from '../modules/movements/arrivals';
 import { loadLockDate } from '../modules/settings/lockDate';
-import {
-  showDeleteConfirmationDialog,
-  hideDeleteConfirmationDialog,
-  showDepartureWizard,
-  showArrivalWizard,
-  createDepartureFromArrival,
-  createArrivalFromDeparture
-} from '../modules/ui/movements';
 
 import MovementsPage from '../components/MovementsPage';
 
 const mapStateToProps = state => {
   return {
-    movements: state.movements,
-    lockDate: state.settings.lockDate,
-    deleteConfirmation: state.ui.movements.deleteConfirmation,
+    lockDate: state.settings.lockDate
   };
 };
 
 const mapActionCreators = {
-  loadDepartures,
-  deleteDeparture,
-  loadArrivals,
-  deleteArrival,
-  loadLockDate,
-  showDeleteConfirmationDialog,
-  hideDeleteConfirmationDialog,
-  showDepartureWizard,
-  showArrivalWizard,
-  createDepartureFromArrival,
-  createArrivalFromDeparture
+  loadLockDate
 };
 
 export default connect(mapStateToProps, mapActionCreators)(MovementsPage);


### PR DESCRIPTION
- Many components extend React.PureComponent now
  -> shouldComponentUpdate does a shallow compare of the props and
     component is only rerendered if they changed
- No inline binding of functions anymore (because there is a new
  function created with bind() and, therefore, the shallow comparison
  in shouldComponentUpdate() returns true which leads to unnecessary
  rerendering)
- Predicates in MovementList are created once
- MovementGroups receives all movements and a predicate and filters
  the movements by itself. This way we can avoid unnecessary
  rerenderings if the movements array is still exactly the same
  (#filter() would create a new array and the MovementGroup would get
  rerendered).