### PR TITLE
Fix security rules for arrival and departure routes

### DIFF
--- a/tasks/processFirebaseRules.js
+++ b/tasks/processFirebaseRules.js
@@ -16,11 +16,11 @@ function processRunway(config) {
 }
 
 function processDepartureRoute(config) {
-  return processRoute(config.aerodrome.departureRoutes, config.ICAO);
+  return processRoute(config.aerodrome.departureRoutes, config.aerodrome.ICAO);
 }
 
 function processArrivalRoute(config) {
-  return processRoute(config.aerodrome.arrivalRoutes, config.ICAO);
+  return processRoute(config.aerodrome.arrivalRoutes, config.aerodrome.ICAO);
 }
 
 function processRoute(routes, aerodrome) {


### PR DESCRIPTION
The rules contained to following string:
`newData.parent().child('location').val().toUpperCase() === 'undefined'`

-> `undefined` should be the ICAO code of the aerodrome (i.e. "LSZT" or "LSZK")