### PR TITLE
Fix layout and infinite scroll issues in VerticalHeaderLayout

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,11 +38,17 @@ const store = createStore(reducer, {}, middleware);
 
 sagaMiddleware.run(autoRestart(sagas));
 
+const handleRouteChange = (prevState, nextState) => {
+  if (nextState.location.action !== 'POP') {
+    window.scrollTo(0, 0);
+  }
+};
+
 ReactDOM.render((
   <Provider store={store}>
     <ThemeProvider theme={theme}>
       <Router history={hashHistory}>
-        <Route path="/" component={App}>
+        <Route path="/" component={App} onChange={handleRouteChange}>
           <IndexRoute component={StartPage}/>
           <Route path="departure/new" component={DeparturePage}/>
           <Route path="departure/new/:arrivalKey" component={DeparturePage}/>

--- a/src/components/VerticalHeaderLayout/Content.js
+++ b/src/components/VerticalHeaderLayout/Content.js
@@ -2,15 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  position: absolute;
-  left: 17%;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  overflow: auto;
+  margin-left: 17%;
   
   @media screen and (max-width: 768px) {
-    left: 0;
+    margin-left: 0;
   }
 `;
 

--- a/src/components/VerticalHeaderLayout/Header.js
+++ b/src/components/VerticalHeaderLayout/Header.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router'
 import Logo from '../Logo';
 
 const Wrapper = styled.header`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   height: 100%;
@@ -14,7 +14,7 @@ const Wrapper = styled.header`
   text-align: center;
   
   @media screen and (max-width: 768px) {
-    width: 0;
+    display: none;
   }
 `;
 

--- a/src/util/AutoLoad.js
+++ b/src/util/AutoLoad.js
@@ -38,8 +38,8 @@ export const AutoLoad = (List) => class extends Component {
         return element;
       }
       element = element.parentNode;
-    } while (element);
-    return null;
+    } while (element && element !== document);
+    return window;
   }
 
   handleScroll(e) {
@@ -49,6 +49,9 @@ export const AutoLoad = (List) => class extends Component {
   }
 
   isEndReached(element) {
+    if (element === document) {
+      return (window.innerHeight + window.scrollY) >= document.body.offsetHeight;
+    }
     return element.offsetHeight + element.scrollTop === element.scrollHeight;
   }
 


### PR DESCRIPTION
- On mobile phones, there was a blank space at the bottom when the address bar
  of the browser wasn't visible (blank space had height of address bar).
- On chromebit, auto appending of movements (infinite scroll) didn't work at
  all (not absolutely sure if this is fixed now).