### PR TITLE
Keep Firebase listeners when Firebase session expires

### DIFF
--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -29,6 +29,7 @@ const olderPredicate = Predicates.and(
 class MovementList extends React.PureComponent {
 
   componentWillMount() {
+    this.props.monitorItems();
     this.props.onSelect(null);
     if (this.props.items.length === 0) {
       this.props.loadItems();
@@ -133,6 +134,7 @@ class MovementList extends React.PureComponent {
 MovementList.propTypes = {
   movementType: PropTypes.oneOf(['departure', 'arrival']),
   loadItems: PropTypes.func.isRequired,
+  monitorItems: PropTypes.func.isRequired,
   items: PropTypes.array.isRequired,
   selected: PropTypes.string,
   onSelect: PropTypes.func,

--- a/src/containers/ArrivalListContainer.js
+++ b/src/containers/ArrivalListContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { loadArrivals, deleteArrival } from '../modules/movements/arrivals';
+import { loadArrivals, monitorArrivals, deleteArrival } from '../modules/movements/arrivals';
 import {
   showDeleteConfirmationDialog,
   hideDeleteConfirmationDialog,
@@ -28,6 +28,7 @@ const mapActionCreators = {
   showDeleteConfirmationDialog,
   hideDeleteConfirmationDialog,
   loadItems: loadArrivals,
+  monitorItems: monitorArrivals,
   deleteItem: deleteArrival,
   onEdit: showArrivalWizard,
   onAction: createDepartureFromArrival,

--- a/src/containers/DepartureListContainer.js
+++ b/src/containers/DepartureListContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { loadDepartures, deleteDeparture } from '../modules/movements/departures';
+import { loadDepartures, monitorDepartures, deleteDeparture } from '../modules/movements/departures';
 import {
   showDeleteConfirmationDialog,
   hideDeleteConfirmationDialog,
@@ -28,6 +28,7 @@ const mapActionCreators = {
   showDeleteConfirmationDialog,
   hideDeleteConfirmationDialog,
   loadItems: loadDepartures,
+  monitorItems: monitorDepartures,
   deleteItem: deleteDeparture,
   onEdit: showDepartureWizard,
   onAction: createArrivalFromDeparture,

--- a/src/modules/movements/arrivals/actions.js
+++ b/src/modules/movements/arrivals/actions.js
@@ -1,4 +1,5 @@
 export const LOAD_ARRIVALS = 'LOAD_ARRIVALS';
+export const MONITOR_ARRIVALS = 'MONITOR_ARRIVALS';
 export const SET_ARRIVALS_LOADING = 'SET_ARRIVALS_LOADING';
 export const LOAD_ARRIVALS_FAILURE = 'LOAD_ARRIVALS_FAILURE';
 export const ARRIVALS_ADDED = 'ARRIVALS_ADDED';
@@ -19,6 +20,12 @@ export function loadArrivals() {
   };
 }
 
+export function monitorArrivals() {
+  return {
+    type: MONITOR_ARRIVALS,
+  };
+}
+
 export function setArrivalsLoading() {
   return {
     type: SET_ARRIVALS_LOADING,
@@ -31,11 +38,12 @@ export function loadArrivalsFailure() {
   };
 }
 
-export function arrivalsAdded(snapshot) {
+export function arrivalsAdded(snapshot, ref) {
   return {
     type: ARRIVALS_ADDED,
     payload: {
       snapshot,
+      ref
     },
   };
 }

--- a/src/modules/movements/arrivals/index.js
+++ b/src/modules/movements/arrivals/index.js
@@ -3,6 +3,7 @@ import sagas from './sagas.js';
 
 export {
   loadArrivals,
+  monitorArrivals,
   deleteArrival,
   initNewArrival,
   initNewArrivalFromDeparture,

--- a/src/modules/movements/arrivals/reducer.js
+++ b/src/modules/movements/arrivals/reducer.js
@@ -21,7 +21,8 @@ const ACTION_HANDLERS = {
 const INITIAL_STATE = {
   data: new ImmutableItemsArray(),
   loading: false,
-  loadingFailed: false
+  loadingFailed: false,
+  refs: []
 };
 
 export default reducer(INITIAL_STATE, ACTION_HANDLERS);

--- a/src/modules/movements/arrivals/sagas.js
+++ b/src/modules/movements/arrivals/sagas.js
@@ -59,6 +59,17 @@ function* loadArrivals(channel) {
   );
 }
 
+export function* monitorArrivals(channel) {
+  yield call(
+    sharedSagas.monitorMovements,
+    state => state.movements.arrivals,
+    channel,
+    actions.arrivalAdded,
+    actions.arrivalChanged,
+    actions.arrivalDeleted
+  );
+}
+
 function* deleteArrival(action) {
   yield sharedSagas.deleteMovement('/arrivals', action.payload.key, action.payload.successAction);
 }
@@ -85,6 +96,7 @@ export default function* sagas() {
   yield [
     fork(monitor, channel),
     fork(takeEvery, actions.LOAD_ARRIVALS, loadArrivals, channel),
+    fork(takeEvery, actions.MONITOR_ARRIVALS, monitorArrivals, channel),
     fork(takeEvery, actions.DELETE_ARRIVAL, deleteArrival),
     fork(takeEvery, actions.INIT_NEW_ARRIVAL, initNewArrival),
     fork(takeEvery, actions.INIT_NEW_ARRIVAL_FROM_DEPARTURE, initNewArrivalFromDeparture),

--- a/src/modules/movements/departures/actions.js
+++ b/src/modules/movements/departures/actions.js
@@ -1,4 +1,5 @@
 export const LOAD_DEPARTURES = 'LOAD_DEPARTURES';
+export const MONITOR_DEPARTURES = 'MONITOR_DEPARTURES';
 export const SET_DEPARTURES_LOADING = 'SET_DEPARTURES_LOADING';
 export const LOAD_DEPARTURES_FAILURE = 'LOAD_DEPARTURES_FAILURE';
 export const DEPARTURES_ADDED = 'DEPARTURES_ADDED';
@@ -19,6 +20,12 @@ export function loadDepartures() {
   };
 }
 
+export function monitorDepartures() {
+  return {
+    type: MONITOR_DEPARTURES,
+  };
+}
+
 export function setDeparturesLoading() {
   return {
     type: SET_DEPARTURES_LOADING,
@@ -31,11 +38,12 @@ export function loadDeparturesFailure() {
   };
 }
 
-export function departuresAdded(snapshot) {
+export function departuresAdded(snapshot, ref) {
   return {
     type: DEPARTURES_ADDED,
     payload: {
       snapshot,
+      ref
     },
   };
 }

--- a/src/modules/movements/departures/index.js
+++ b/src/modules/movements/departures/index.js
@@ -3,6 +3,7 @@ import sagas from './sagas.js';
 
 export {
   loadDepartures,
+  monitorDepartures,
   deleteDeparture,
   initNewDeparture,
   initNewDepartureFromArrival,

--- a/src/modules/movements/departures/reducer.js
+++ b/src/modules/movements/departures/reducer.js
@@ -21,7 +21,8 @@ const ACTION_HANDLERS = {
 const INITIAL_STATE = {
   data: new ImmutableItemsArray(),
   loading: false,
-  loadingFailed: false
+  loadingFailed: false,
+  refs: []
 };
 
 export default reducer(INITIAL_STATE, ACTION_HANDLERS);

--- a/src/modules/movements/departures/sagas.js
+++ b/src/modules/movements/departures/sagas.js
@@ -56,6 +56,17 @@ export function* loadDepartures(channel) {
   );
 }
 
+export function* monitorDepartures(channel) {
+  yield call(
+    sharedSagas.monitorMovements,
+    state => state.movements.departures,
+    channel,
+    actions.departureAdded,
+    actions.departureChanged,
+    actions.departureDeleted
+  );
+}
+
 export function* deleteDeparture(action) {
   yield call(sharedSagas.deleteMovement, '/departures', action.payload.key, action.payload.successAction);
 }
@@ -82,6 +93,7 @@ export default function* sagas() {
   yield [
     fork(monitor, channel),
     fork(takeEvery, actions.LOAD_DEPARTURES, loadDepartures, channel),
+    fork(takeEvery, actions.MONITOR_DEPARTURES, monitorDepartures, channel),
     fork(takeEvery, actions.DELETE_DEPARTURE, deleteDeparture),
     fork(takeEvery, actions.INIT_NEW_DEPARTURE, initNewDeparture),
     fork(takeEvery, actions.INIT_NEW_DEPARTURE_FROM_ARRIVAL, initNewDepartureFromArrival),

--- a/src/modules/movements/shared/reducers.js
+++ b/src/modules/movements/shared/reducers.js
@@ -11,7 +11,7 @@ export default function (initialState, actionHandlers) {
 }
 
 export function childrenAdded(state, action) {
-  const snapshot = action.payload.snapshot;
+  const {snapshot, ref} = action.payload;
 
   const movements = [];
 
@@ -24,6 +24,7 @@ export function childrenAdded(state, action) {
   return Object.assign({}, state, {
     data: state.data.insertAll(movements, compareDescending),
     loading: false,
+    refs: state.refs.concat(ref)
   });
 }
 

--- a/src/modules/movements/shared/remote.js
+++ b/src/modules/movements/shared/remote.js
@@ -1,27 +1,16 @@
 import firebase from '../../../util/firebase';
 
-export function loadLimited(path, start, limit, childAdded, childChanged, childRemoved) {
+export function loadLimited(path, start, limit) {
   return new Promise(resolve => {
     const ref = firebase(path)
       .orderByChild('negativeTimestamp')
       .limitToFirst(limit)
       .startAt(start);
-    let newItems = false;
     ref.once('value', snapshot => {
-      newItems = true;
-      resolve(snapshot);
-    });
-    ref.on('child_added', snapshot => {
-      if (!newItems) return;
-      childAdded(snapshot);
-    });
-    ref.on('child_changed', snapshot => {
-      if (!newItems) return;
-      childChanged(snapshot);
-    });
-    ref.on('child_removed', snapshot => {
-      if (!newItems) return;
-      childRemoved(snapshot);
+      resolve({
+        snapshot,
+        ref
+      });
     });
   });
 }

--- a/src/modules/movements/shared/sagas.spec.js
+++ b/src/modules/movements/shared/sagas.spec.js
@@ -2,9 +2,12 @@ import expect from 'expect';
 import { select, put, call } from 'redux-saga/effects';
 import { initialize, getFormValues, destroy } from 'redux-form';
 import dates from '../../../util/dates';
+import ImmutableItemsArray from '../../../util/ImmutableItemsArray';
 import * as actions from './actions';
 import * as sagas from './sagas';
 import * as remote from './remote';
+import {LIMIT} from './pagination';
+import Utils from '../../../../test/Utils';
 
 describe('modules', () => {
   describe('movements', () => {
@@ -63,6 +66,152 @@ describe('modules', () => {
 
             expect(generator.next().done).toEqual(true);
           });
+        });
+      });
+
+      describe('loadMovements', () => {
+        it('should load new movements range', () => {
+          const setLoadingAction = () => ({type: 'LOADING'});
+          const failureAction = () => ({type: 'FAILURE'});
+          const stateSelector = () => {};
+          const firebasePath = '/movements';
+          const channel = {
+            put: Utils.callTracker()
+          };
+          const successAction = (snapshot, ref) => ({type: 'SUCCESS', payload: {snapshot, ref}});
+          const childAddedAction = () => {};
+          const childChangedAction = () => {};
+          const childRemovedAction = () => {};
+
+          const generator = sagas.loadMovements(
+            setLoadingAction,
+            failureAction,
+            stateSelector,
+            firebasePath,
+            channel,
+            successAction,
+            childAddedAction,
+            childChangedAction,
+            childRemovedAction
+          );
+
+          expect(generator.next().value).toEqual(select(stateSelector));
+
+          const state = {
+            loading: false,
+            data: new ImmutableItemsArray()
+          };
+
+          expect(generator.next(state).value).toEqual(put(setLoadingAction()));
+
+          expect(generator.next().value).toEqual(call(remote.loadLimited, firebasePath, undefined, LIMIT));
+
+          const snapshot = {};
+          const ref = {};
+
+          const result = {
+            snapshot,
+            ref
+          };
+
+          const monitorCall = generator.next(result).value.CALL;
+          expect(monitorCall.fn).toBe(sagas.monitorRef);
+          expect(monitorCall.args[0]).toBe(ref);
+          expect(typeof monitorCall.args[1]).toEqual('function');
+          expect(typeof monitorCall.args[2]).toEqual('function');
+          expect(typeof monitorCall.args[3]).toEqual('function');
+
+          expect(generator.next().done).toEqual(true);
+
+          const channelPutCalls = channel.put.calls();
+          expect(channelPutCalls.length).toBe(1);
+          expect(channelPutCalls[0].length).toBe(1);
+          expect(channelPutCalls[0][0].type).toEqual('SUCCESS');
+          expect(channelPutCalls[0][0].payload.snapshot).toBe(snapshot);
+          expect(channelPutCalls[0][0].payload.ref).toBe(ref);
+        });
+      });
+
+      describe('monitorMovements', () => {
+        it('should add listener on all refs', () => {
+          const stateSelector = () => {};
+          const channel = {
+            put: Utils.callTracker()
+          };
+          const childAddedAction = () => {};
+          const childChangedAction = () => {};
+          const childRemovedAction = () => {};
+
+          const generator = sagas.monitorMovements(
+            stateSelector,
+            channel,
+            childAddedAction,
+            childChangedAction,
+            childRemovedAction
+          );
+
+          expect(generator.next().value).toEqual(select(stateSelector));
+
+          const ref1 = {};
+          const ref2 = {};
+
+          const state = {
+            refs: [ref1, ref2]
+          };
+
+          const ref1Call = generator.next(state).value.CALL;
+          expect(ref1Call.fn).toBe(sagas.monitorRef);
+          expect(ref1Call.args[0]).toBe(ref1);
+          expect(typeof ref1Call.args[1]).toEqual('function');
+          expect(typeof ref1Call.args[2]).toEqual('function');
+          expect(typeof ref1Call.args[3]).toEqual('function');
+
+          const ref2Call = generator.next().value.CALL;
+          expect(ref2Call.fn).toBe(sagas.monitorRef);
+          expect(ref2Call.args[0]).toBe(ref2);
+          expect(typeof ref2Call.args[1]).toEqual('function');
+          expect(typeof ref2Call.args[2]).toEqual('function');
+          expect(typeof ref2Call.args[3]).toEqual('function');
+
+          expect(generator.next().done).toEqual(true);
+        });
+      });
+
+      describe('monitorRef', () => {
+        it('should remove old listeners and attach new ones', () => {
+          const ref = {
+            off: Utils.callTracker(),
+            on: Utils.callTracker()
+          };
+
+          const childAdded = () => {};
+          const childChanged = () => {};
+          const childRemoved = () => {};
+
+          const generator = sagas.monitorRef(ref, childAdded, childChanged, childRemoved);
+
+          expect(generator.next().done).toEqual(true);
+
+          const offCalls = ref.off.calls();
+          expect(offCalls.length).toBe(3);
+          expect(offCalls[0].length).toBe(1);
+          expect(offCalls[0][0]).toBe('child_added');
+          expect(offCalls[1].length).toBe(1);
+          expect(offCalls[1][0]).toBe('child_changed');
+          expect(offCalls[2].length).toBe(1);
+          expect(offCalls[2][0]).toBe('child_removed');
+
+          const onCalls = ref.on.calls();
+          expect(onCalls.length).toBe(3);
+          expect(onCalls[0].length).toBe(2);
+          expect(onCalls[0][0]).toBe('child_added');
+          expect(onCalls[0][1]).toBe(childAdded);
+          expect(onCalls[1].length).toBe(2);
+          expect(onCalls[1][0]).toBe('child_changed');
+          expect(onCalls[1][1]).toBe(childChanged);
+          expect(onCalls[2].length).toBe(2);
+          expect(onCalls[2][0]).toBe('child_removed');
+          expect(onCalls[2][1]).toBe(childRemoved);
         });
       });
     });


### PR DESCRIPTION
Until now, we added `child_added`, `child_changed` and `child_removed`
listeners on the Firebase query in remote#loadLimited. These listeners were
supposed to live forever to receive all subsequent events on the loaded range.

Albeit supposed to live forever, Firebase cancelled the listeners once the
current session expired (which is the case after 24h). The listeners get
removed, because the client is not allowed to access the node for a short
amount of time, until the session has been refreshed with a new token.

Fix:

To ensure that there are listeners for the loaded ranges, we keep the query
references in our state and register the listeners in
MovementList#componentWillMount() (which will be called after the session has
been refreshed).
Also, the listeners are still getting registered directly after a range has been
loaded using `remote.loadLimited` (see `loadMovements` saga).