### PR TITLE
Clear previously loaded movements when list is mounted

### DIFF
--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -31,11 +31,8 @@ class MovementList extends React.PureComponent {
 
   componentWillMount() {
     this.props.loadAircraftSettings();
-    this.props.monitorItems();
     this.props.onSelect(null);
-    if (this.props.items.array.length === 0) {
-      this.props.loadItems();
-    }
+    this.props.loadItems(true);
   }
 
   getDateString(movement) {
@@ -153,7 +150,6 @@ class MovementList extends React.PureComponent {
 MovementList.propTypes = {
   loadItems: PropTypes.func.isRequired,
   loadAircraftSettings: PropTypes.func.isRequired,
-  monitorItems: PropTypes.func.isRequired,
   items: PropTypes.object.isRequired,
   selected: PropTypes.string,
   onSelect: PropTypes.func,

--- a/src/containers/MovementListContainer.js
+++ b/src/containers/MovementListContainer.js
@@ -29,7 +29,6 @@ const mapActionCreators = {
   createMovementFromMovement,
   loadAircraftSettings,
   loadItems: loadMovements,
-  monitorItems: monitorMovements,
   deleteItem: deleteMovement,
   onEdit: showMovementWizard,
   onSelect: selectMovement,

--- a/src/modules/movements/actions.js
+++ b/src/modules/movements/actions.js
@@ -1,5 +1,4 @@
 export const LOAD_MOVEMENTS = 'LOAD_MOVEMENTS';
-export const MONITOR_MOVEMENTS = 'MONITOR_MOVEMENTS';
 export const SET_MOVEMENTS_LOADING = 'SET_MOVEMENTS_LOADING';
 export const LOAD_MOVEMENTS_FAILURE = 'LOAD_MOVEMENTS_FAILURE';
 export const MOVEMENTS_ADDED = 'MOVEMENTS_ADDED';
@@ -16,15 +15,12 @@ export const EDIT_MOVEMENT = 'EDIT_MOVEMENT';
 export const START_INITIALIZE_WIZARD = 'START_INITIALIZE_WIZARD';
 export const WIZARD_INITIALIZED = 'WIZARD_INITIALIZED';
 
-export function loadMovements() {
+export function loadMovements(clear) {
   return {
     type: LOAD_MOVEMENTS,
-  };
-}
-
-export function monitorMovements() {
-  return {
-    type: MONITOR_MOVEMENTS,
+    payload: {
+      clear
+    }
   };
 }
 
@@ -40,13 +36,13 @@ export function loadMovementsFailure() {
   };
 }
 
-export function movementsAdded(snapshot, ref, movementType) {
+export function movementsAdded(snapshot, movementType, clear) {
   return {
     type: MOVEMENTS_ADDED,
     payload: {
       snapshot,
-      ref,
-      movementType
+      movementType,
+      clear
     },
   };
 }

--- a/src/modules/movements/index.js
+++ b/src/modules/movements/index.js
@@ -7,7 +7,6 @@ export {
   START_INITIALIZE_WIZARD,
   WIZARD_INITIALIZED,
   loadMovements,
-  monitorMovements,
   deleteMovement,
   initNewMovement,
   initNewMovementFromMovement,

--- a/src/modules/movements/reducer.js
+++ b/src/modules/movements/reducer.js
@@ -4,7 +4,7 @@ import { firebaseToLocal, compareDescending } from '../../util/movements';
 import associate from './associate';
 
 export function childrenAdded(state, action) {
-  const {snapshot, ref, movementType} = action.payload;
+  const {snapshot, movementType, clear} = action.payload;
 
   const movements = [];
 
@@ -15,18 +15,14 @@ export function childrenAdded(state, action) {
     movements.push(movement);
   });
 
-  let newData = state.data.insertAll(movements, compareDescending);
-  newData = associate(newData, compareDescending);
+  const existingMovements = clear ? new ImmutableItemsArray() : state.data;
 
-  const newRefs = state.refs.concat({
-    type: movementType,
-    ref
-  });
+  let newData = existingMovements.insertAll(movements, compareDescending);
+  newData = associate(newData, compareDescending);
 
   return Object.assign({}, state, {
     data: newData,
-    loading: false,
-    refs: newRefs
+    loading: false
   });
 }
 
@@ -97,8 +93,7 @@ const ACTION_HANDLERS = {
 const INITIAL_STATE = {
   data: new ImmutableItemsArray(),
   loading: false,
-  loadingFailed: false,
-  refs: []
+  loadingFailed: false
 };
 
 const reducer = (initialState, actionHandlers) => {

--- a/src/modules/movements/reducer.spec.js
+++ b/src/modules/movements/reducer.spec.js
@@ -10,12 +10,6 @@ describe('modules', () => {
       describe('childrenAdded', () => {
         it('should add children', () => {
           const state = {
-            refs: [{
-              type: 'departure',
-              ref: {
-                name: 'ref1'
-              }
-            }],
             loading: true,
             data: new ImmutableItemsArray([{
               key: 'dep2',
@@ -42,23 +36,11 @@ describe('modules', () => {
               dateTime: '2017-04-28T15:00:00.000Z'
             })
           ]);
-          const action = actions.movementsAdded(snapshot, {name: 'ref2'}, 'arrival');
+          const action = actions.movementsAdded(snapshot, 'arrival');
 
           const newState = reducer.childrenAdded(state, action);
 
           expect(newState.loading).toEqual(false);
-
-          expect(newState.refs).toEqual([{
-            type: 'departure',
-            ref: {
-              name: 'ref1'
-            }
-          }, {
-            type: 'arrival',
-            ref: {
-              name: 'ref2'
-            }
-          }]);
 
           // `key` must have been added
           // `type: 'departure'` must have been added
@@ -104,6 +86,69 @@ describe('modules', () => {
             associations: {
               preceding: null,
               subsequent: 'arr2'
+            }
+          }]);
+        });
+
+        it('should clear existing children if flag set', () => {
+          const state = {
+            loading: true,
+            data: new ImmutableItemsArray([{
+              key: 'dep2',
+              type: 'departure',
+              immatriculation: 'HBKOF',
+              date: '2017-04-28',
+              time: '15:00'
+            }, {
+              key: 'dep1',
+              type: 'departure',
+              immatriculation: 'HBKFW',
+              date: '2017-04-28',
+              time: '14:00'
+            }])
+          };
+
+          const snapshot = new FakeFirebaseSnapshot(null, [
+            new FakeFirebaseSnapshot('arr1', {
+              immatriculation: 'HBKOF',
+              dateTime: '2017-04-28T14:00:00.000Z'
+            }),
+            new FakeFirebaseSnapshot('arr2', {
+              immatriculation: 'HBKFW',
+              dateTime: '2017-04-28T15:00:00.000Z'
+            })
+          ]);
+          const action = actions.movementsAdded(snapshot, 'arrival', true);
+
+          const newState = reducer.childrenAdded(state, action);
+
+          expect(newState.loading).toEqual(false);
+
+          // `key` must have been added
+          // `type: 'departure'` must have been added
+          // `dateTime` must have been converted to `date` and `time` in local time
+          // existing items must have been removed
+          // items must have been inserted in the right order
+          // associations must have been added
+          expect(newState.data.array).toEqual([{
+            key: 'arr2',
+            date: '2017-04-28',
+            immatriculation: 'HBKFW',
+            time: '17:00',
+            type: 'arrival',
+            associations: {
+              preceding: null,
+              subsequent: null
+            }
+          }, {
+            key: 'arr1',
+            date: '2017-04-28',
+            immatriculation: 'HBKOF',
+            time: '16:00',
+            type: 'arrival',
+            associations: {
+              preceding: null,
+              subsequent: null
             }
           }]);
         });

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -94,13 +94,15 @@ export function getOldest(snapshot) {
   return oldest;
 }
 
-export function* loadMovements(channel) {
+export function* loadMovements(channel, action) {
   try {
+    const {clear} = action.payload;
+
     const movements = yield select(stateSelector);
     if (movements.loading !== true) {
       yield put(actions.setMovementsLoading());
 
-      const pagination = getPagination(movements.data.array);
+      const pagination = getPagination(clear ? [] : movements.data.array);
 
       const departures = yield call(
         remote.loadLimited,
@@ -131,8 +133,8 @@ export function* loadMovements(channel) {
       yield call(monitorRef, departures.ref, channel, 'departure');
       yield call(monitorRef, arrivals.ref, channel, 'arrival');
 
-      channel.put(actions.movementsAdded(departures.snapshot, departures.ref, 'departure'));
-      channel.put(actions.movementsAdded(arrivals.snapshot, arrivals.ref, 'arrival'));
+      channel.put(actions.movementsAdded(departures.snapshot, 'departure', clear));
+      channel.put(actions.movementsAdded(arrivals.snapshot, 'arrival', clear));
     }
   } catch(e) {
     error('Failed to load movements', e);
@@ -156,14 +158,6 @@ export function* monitorRef(ref, channel, movementType) {
 
 export function createDelegate(channel, action, movementType) {
   return snapshot => channel.put(action(snapshot, movementType))
-}
-
-export function* monitorMovements(channel) {
-  const state = yield select(stateSelector);
-
-  for (const ref of state.refs) {
-    yield call(monitorRef, ref.ref, channel, ref.type);
-  }
 }
 
 export function* deleteMovement(action) {
@@ -254,7 +248,6 @@ export default function* sagas() {
   yield [
     fork(monitor, channel),
     fork(takeEvery, actions.LOAD_MOVEMENTS, loadMovements, channel),
-    fork(takeEvery, actions.MONITOR_MOVEMENTS, monitorMovements, channel),
     fork(takeEvery, actions.DELETE_MOVEMENT, deleteMovement),
     fork(takeEvery, actions.INIT_NEW_MOVEMENT, initNewMovement),
     fork(takeEvery, actions.INIT_NEW_MOVEMENT_FROM_MOVEMENT, initNewMovementFromMovement),


### PR DESCRIPTION
Rendering a lot of movements is not that fast and we just don't have to keep
that many old ones in the list. Whenever needed, they can be fetched.