### PR TITLE
Fix scroll-to-top bug after react-router update

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,12 +35,6 @@ const store = createStore(reducer, {}, middleware);
 
 sagaMiddleware.run(autoRestart(sagas));
 
-const handleRouteChange = (prevState, nextState) => {
-  if (nextState.location.action !== 'POP') {
-    window.scrollTo(0, 0);
-  }
-};
-
 ReactDOM.render((
   <Provider store={store}>
     <ThemeProvider theme={theme}>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -13,6 +13,12 @@ import ArrivalPage from "../../containers/ArrivalPageContainer";
 
 class App extends React.PureComponent {
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.history.action !== 'POP') {
+      window.scrollTo(0, 0);
+    }
+  }
+
   render() {
     const props = this.props;
     if (props.auth.initialized !== true) {
@@ -45,6 +51,9 @@ class App extends React.PureComponent {
 App.propTypes = {
   auth: PropTypes.object.isRequired,
   showLogin: PropTypes.bool.isRequired,
+  history: PropTypes.shape({
+    action: PropTypes.string.isRequired
+  }).isRequired
 };
 
 export default App;


### PR DESCRIPTION
There was an `onChange` handler on the root route (which rendered the
<App> component) before the react-router update to scroll to the top.
when the location changes.
The event handler hasn't been migrated to the new API so far.
Since react-router routes are real React components now, the React
lifecycle methods can be used now - `componentWillReceiveProps` in
this case (there is no onChange event and the like anymore on the
react-router components (i.e. Route)).