### PR TITLE
Use PropTypes from extracted package `prop-types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8826,9 +8826,9 @@
       }
     },
     "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -9037,7 +9037,7 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-addons-test-utils": {
@@ -9075,7 +9075,7 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-hot-loader": {
@@ -9087,7 +9087,7 @@
         "fast-levenshtein": "2.0.6",
         "global": "4.3.2",
         "hoist-non-react-statics": "2.5.0",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "shallowequal": "1.0.2"
       }
     },
@@ -9102,7 +9102,7 @@
         "lodash": "4.17.5",
         "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "lodash": {
@@ -9130,7 +9130,7 @@
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
         "path-to-regexp": "1.7.0",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "warning": "3.0.0"
       },
       "dependencies": {
@@ -9154,7 +9154,7 @@
         "history": "4.7.2",
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-router": "4.2.0",
         "warning": "3.0.0"
       }
@@ -9166,7 +9166,7 @@
       "dev": true,
       "requires": {
         "history": "4.7.2",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-router": "4.2.0"
       }
     },
@@ -10741,7 +10741,7 @@
         "fbjs": "0.8.16",
         "hoist-non-react-statics": "2.5.0",
         "is-plain-object": "2.0.4",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "stylis": "3.5.0",
         "stylis-rule-sheet": "0.0.10",
         "supports-color": "3.2.3"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "moment": "^2.22.0",
     "moment-timezone": "^0.5.11",
     "node-sass": "^4.8.3",
+    "prop-types": "^15.6.1",
     "ramda": "^0.25.0",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",

--- a/src/components/AdminPage/AdminPage.js
+++ b/src/components/AdminPage/AdminPage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter } from "react-router-dom";
 import LabeledBox from '../LabeledBox';
@@ -63,7 +64,7 @@ class AdminPage extends Component {
 }
 
 AdminPage.propTypes = {
-  auth: React.PropTypes.object.isRequired,
+  auth: PropTypes.object.isRequired,
 };
 
 export default withRouter(AdminPage);

--- a/src/components/AerodromeDropdown/AerodromeDropdown.js
+++ b/src/components/AerodromeDropdown/AerodromeDropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dropdown from '../Dropdown';
 import Option from './Option';
@@ -57,12 +58,12 @@ const AerodromeDropdown = props => (
 );
 
 AerodromeDropdown.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  aerodromes: React.PropTypes.object.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  readOnly: React.PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  aerodromes: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 export default AerodromeDropdown;

--- a/src/components/AerodromeDropdown/Option.js
+++ b/src/components/AerodromeDropdown/Option.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -23,9 +24,9 @@ const Option = props => (
 );
 
 Option.propTypes = {
-  code: React.PropTypes.string.isRequired,
-  name: React.PropTypes.string.isRequired,
-  focussed: React.PropTypes.bool
+  code: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  focussed: PropTypes.bool
 };
 
 export default Option;

--- a/src/components/AerodromeImportForm/AerodromeImportForm.js
+++ b/src/components/AerodromeImportForm/AerodromeImportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import CsvImportForm, { Example } from '../CsvImportForm';
 import P from '../P';
@@ -43,14 +44,14 @@ const AerodromeImportForm = props => {
 };
 
 AerodromeImportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  importInProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
-  closeDoneDialog: React.PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  importInProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
+  closeDoneDialog: PropTypes.func.isRequired,
 };
 
 export default AerodromeImportForm;

--- a/src/components/AircraftDropdown/AircraftDropdown.js
+++ b/src/components/AircraftDropdown/AircraftDropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dropdown from '../Dropdown';
 import Option from './Option';
@@ -54,12 +55,12 @@ const AircraftDropdown = props => (
 );
 
 AircraftDropdown.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  aircrafts: React.PropTypes.object.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  readOnly: React.PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  aircrafts: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 export default AircraftDropdown;

--- a/src/components/AircraftDropdown/Option.js
+++ b/src/components/AircraftDropdown/Option.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -23,9 +24,9 @@ const Option = props => (
 );
 
 Option.propTypes = {
-  immatriculation: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string.isRequired,
-  focussed: React.PropTypes.bool
+  immatriculation: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  focussed: PropTypes.bool
 };
 
 export default Option;

--- a/src/components/AircraftImportForm/AircraftImportForm.js
+++ b/src/components/AircraftImportForm/AircraftImportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import CsvImportForm, { Example } from '../CsvImportForm';
 import P from '../P';
@@ -43,14 +44,14 @@ const AircraftImportForm = props => {
 };
 
 AircraftImportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  importInProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
-  closeDoneDialog: React.PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  importInProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
+  closeDoneDialog: PropTypes.func.isRequired,
 };
 
 export default AircraftImportForm;

--- a/src/components/AirstatReportForm/AirstatReportForm.js
+++ b/src/components/AirstatReportForm/AirstatReportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReportForm from '../ReportForm';
 import InternalReportCheckbox from './InternalReportCheckbox';
@@ -16,15 +17,15 @@ const AirstatReportForm = props => (
 );
 
 AirstatReportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
-    month: React.PropTypes.number,
+  disabled: PropTypes.bool,
+  date: PropTypes.shape({
+    year: PropTypes.number,
+    month: PropTypes.number,
   }),
-  internal: React.PropTypes.bool,
-  setDate: React.PropTypes.func.isRequired,
-  setInternal: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  internal: PropTypes.bool,
+  setDate: PropTypes.func.isRequired,
+  setInternal: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 export default AirstatReportForm;

--- a/src/components/AirstatReportForm/InternalReportCheckbox.js
+++ b/src/components/AirstatReportForm/InternalReportCheckbox.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -23,8 +24,8 @@ const InternalReportCheckbox = props => (
 );
 
 InternalReportCheckbox.propTypes = {
-  internal: React.PropTypes.bool.isRequired,
-  setInternal: React.PropTypes.func.isRequired
+  internal: PropTypes.bool.isRequired,
+  setInternal: PropTypes.func.isRequired
 };
 
 export default InternalReportCheckbox;

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Switch, Route, Redirect} from 'react-router-dom';
 import LoginPage from '../../containers/LoginPageContainer';
 import Centered from '../Centered';

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import MaterialIcon from '../MaterialIcon';
 import StyledButton from './StyledButton';
@@ -53,16 +54,16 @@ class Button extends React.Component {
 }
 
 Button.propTypes = {
-  type: React.PropTypes.oneOf(['submit', 'button', 'reset']),
-  label: React.PropTypes.string.isRequired,
-  icon: React.PropTypes.string,
-  className: React.PropTypes.string,
-  disabled: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
-  primary: React.PropTypes.bool,
-  flat: React.PropTypes.bool,
-  danger: React.PropTypes.bool,
-  neutral: React.PropTypes.bool
+  type: PropTypes.oneOf(['submit', 'button', 'reset']),
+  label: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  primary: PropTypes.bool,
+  flat: PropTypes.bool,
+  danger: PropTypes.bool,
+  neutral: PropTypes.bool
 };
 
 Button.defaultProps = {

--- a/src/components/CancelConfirmationDialog/CancelConfirmationDialog.js
+++ b/src/components/CancelConfirmationDialog/CancelConfirmationDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ModalDialog from '../ModalDialog';
 import MaterialIcon from '../MaterialIcon';
 import './CancelConfirmationDialog.scss';

--- a/src/components/CommitFailureDialog/CommitFailureDialog.js
+++ b/src/components/CommitFailureDialog/CommitFailureDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ModalDialog from '../ModalDialog';
 import Heading from './Heading';
 import ErrorMessage from './ErrorMessage';

--- a/src/components/CsvImportForm/CsvImportForm.js
+++ b/src/components/CsvImportForm/CsvImportForm.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import FileInput from '../FileInput';
 import Button from '../Button';
 import ImportDoneDialog from './ImportDoneDialog';

--- a/src/components/CsvImportForm/ImportDoneDialog.js
+++ b/src/components/CsvImportForm/ImportDoneDialog.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import ModalDialog from '../ModalDialog';
@@ -33,9 +34,9 @@ const ImportDoneDialog = props => {
 };
 
 ImportDoneDialog.propTypes = {
-  doneHeading: React.PropTypes.string.isRequired,
-  doneMessage: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired,
+  doneHeading: PropTypes.string.isRequired,
+  doneMessage: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default ImportDoneDialog;

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ModalDialog from '../ModalDialog';
 import MaterialIcon from '../MaterialIcon';
 import ReactDatePicker from 'react-date-picker';

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import scrollIntoView from 'scroll-into-view';
 import MaterialIcon from '../MaterialIcon';
@@ -339,22 +340,22 @@ class Dropdown extends Component {
 }
 
 Dropdown.propTypes = {
-  className: React.PropTypes.string,
-  options: React.PropTypes.array.isRequired,
-  value: React.PropTypes.string,
-  optionRenderer: React.PropTypes.func.isRequired,
-  valueRenderer: React.PropTypes.func,
-  optionFilter: React.PropTypes.func,
-  noOptionsText: React.PropTypes.string,
-  moreOptionsText: React.PropTypes.string,
-  mustSelect: React.PropTypes.bool,
-  clearable: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  onBeforeInputChange: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onBlur: React.PropTypes.func,
-  readOnly: React.PropTypes.bool,
-  optionsRenderLimit: React.PropTypes.number,
+  className: PropTypes.string,
+  options: PropTypes.array.isRequired,
+  value: PropTypes.string,
+  optionRenderer: PropTypes.func.isRequired,
+  valueRenderer: PropTypes.func,
+  optionFilter: PropTypes.func,
+  noOptionsText: PropTypes.string,
+  moreOptionsText: PropTypes.string,
+  mustSelect: PropTypes.bool,
+  clearable: PropTypes.bool,
+  onChange: PropTypes.func,
+  onBeforeInputChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  readOnly: PropTypes.bool,
+  optionsRenderLimit: PropTypes.number,
 };
 
 Dropdown.defaultProps = {

--- a/src/components/FileInput/FileInput.js
+++ b/src/components/FileInput/FileInput.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -58,11 +59,11 @@ const FileInput = props => (
 );
 
 FileInput.propTypes = {
-  value: React.PropTypes.shape({
-    name: React.PropTypes.string.isRequired,
+  value: PropTypes.shape({
+    name: PropTypes.string.isRequired,
   }),
-  onChange: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 export default FileInput;

--- a/src/components/HelpPage/QuestionsList.js
+++ b/src/components/HelpPage/QuestionsList.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -22,10 +23,10 @@ const QuestionsList = props => (
 );
 
 QuestionsList.propTypes = {
-  questions: React.PropTypes.arrayOf(React.PropTypes.shape({
-    question: React.PropTypes.string.isRequired
+  questions: PropTypes.arrayOf(PropTypes.shape({
+    question: PropTypes.string.isRequired
   })).isRequired,
-  onClick: React.PropTypes.func.isRequired
+  onClick: PropTypes.func.isRequired
 };
 
 export default QuestionsList;

--- a/src/components/ImageButton/ImageButton.js
+++ b/src/components/ImageButton/ImageButton.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 

--- a/src/components/IncrementationField/IncrementationField.js
+++ b/src/components/IncrementationField/IncrementationField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Button from './Button';
 import Value from './Value';
 

--- a/src/components/ItemList/Item.js
+++ b/src/components/ItemList/Item.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -31,8 +32,8 @@ const Item = props => (
 );
 
 Item.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  onRemoveClick: React.PropTypes.func,
+  name: PropTypes.string.isRequired,
+  onRemoveClick: PropTypes.func,
 };
 
 export default Item;

--- a/src/components/ItemList/ItemList.js
+++ b/src/components/ItemList/ItemList.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -67,11 +68,11 @@ const ItemList = props => (
 );
 
 ItemList.propTypes = {
-  items: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-  newItem: React.PropTypes.string.isRequired,
-  changeNewItem: React.PropTypes.func.isRequired,
-  addItem: React.PropTypes.func.isRequired,
-  removeItem: React.PropTypes.func.isRequired,
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  newItem: PropTypes.string.isRequired,
+  changeNewItem: PropTypes.func.isRequired,
+  addItem: PropTypes.func.isRequired,
+  removeItem: PropTypes.func.isRequired,
 };
 
 export default ItemList;

--- a/src/components/JumpNavigation/Item.js
+++ b/src/components/JumpNavigation/Item.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
@@ -37,9 +38,9 @@ const Item = props => (
 );
 
 Item.propTypes = {
-  href: React.PropTypes.string,
-  icon: React.PropTypes.string,
-  label: React.PropTypes.string
+  href: PropTypes.string,
+  icon: PropTypes.string,
+  label: PropTypes.string
 };
 
 export default Item;

--- a/src/components/LabeledBox/LabeledBox.js
+++ b/src/components/LabeledBox/LabeledBox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`

--- a/src/components/LabeledComponent/LabeledComponent.js
+++ b/src/components/LabeledComponent/LabeledComponent.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Label from './Label';
 import ComponentContainer from './ComponentContainer';
 import Tooltip from './Tooltip';

--- a/src/components/LabeledComponent/ValidationMessage.js
+++ b/src/components/LabeledComponent/ValidationMessage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -30,7 +31,7 @@ class ValidationMessage extends React.PureComponent {
 }
 
 ValidationMessage.propTypes = {
-  error: React.PropTypes.string.isRequired,
+  error: PropTypes.string.isRequired,
 };
 
 export default ValidationMessage;

--- a/src/components/LocationConfirmationDialog/LocationConfirmationDialog.js
+++ b/src/components/LocationConfirmationDialog/LocationConfirmationDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 import ModalDialog from '../ModalDialog';
 import Button from '../Button';

--- a/src/components/LockMovementsForm/LockMovementsForm.js
+++ b/src/components/LockMovementsForm/LockMovementsForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import LabeledComponent from './StyledLabeledComponent';
 import LabeledBox from '../LabeledBox';
@@ -37,9 +38,9 @@ class LockMovementsForm extends Component {
 }
 
 LockMovementsForm.propTypes = {
-  lockDate: React.PropTypes.object.isRequired,
-  loadLockDate: React.PropTypes.func.isRequired,
-  setLockDate: React.PropTypes.func.isRequired,
+  lockDate: PropTypes.object.isRequired,
+  loadLockDate: PropTypes.func.isRequired,
+  setLockDate: PropTypes.func.isRequired,
 };
 
 export default LockMovementsForm;

--- a/src/components/LoginPage/Failure.js
+++ b/src/components/LoginPage/Failure.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -11,7 +12,7 @@ const Failure = props => (
 );
 
 Failure.propTypes = {
-  failure: React.PropTypes.bool.isRequired
+  failure: PropTypes.bool.isRequired
 };
 
 export default Failure;

--- a/src/components/LoginPage/LoginPage.js
+++ b/src/components/LoginPage/LoginPage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Header from './Header';
 import Main from './Main';
@@ -20,15 +21,15 @@ const LoginPage = props => (
 );
 
 LoginPage.propTypes = {
-  authenticate: React.PropTypes.func.isRequired,
-  updateUsername: React.PropTypes.func.isRequired,
-  updatePassword: React.PropTypes.func.isRequired,
-  onCancel: React.PropTypes.func.isRequired,
-  showCancel: React.PropTypes.bool.isRequired,
-  username: React.PropTypes.string.isRequired,
-  password: React.PropTypes.string.isRequired,
-  submitting: React.PropTypes.bool.isRequired,
-  failure: React.PropTypes.bool.isRequired
+  authenticate: PropTypes.func.isRequired,
+  updateUsername: PropTypes.func.isRequired,
+  updatePassword: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  showCancel: PropTypes.bool.isRequired,
+  username: PropTypes.string.isRequired,
+  password: PropTypes.string.isRequired,
+  submitting: PropTypes.bool.isRequired,
+  failure: PropTypes.bool.isRequired
 };
 
 export default LoginPage;

--- a/src/components/LoginPage/Main.js
+++ b/src/components/LoginPage/Main.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import LabeledComponent from '../LabeledComponent';
@@ -90,15 +91,15 @@ const Main = props => {
 };
 
 Main.propTypes = {
-  authenticate: React.PropTypes.func.isRequired,
-  updateUsername: React.PropTypes.func.isRequired,
-  updatePassword: React.PropTypes.func.isRequired,
-  onCancel: React.PropTypes.func.isRequired,
-  showCancel: React.PropTypes.bool.isRequired,
-  username: React.PropTypes.string.isRequired,
-  password: React.PropTypes.string.isRequired,
-  submitting: React.PropTypes.bool.isRequired,
-  failure: React.PropTypes.bool.isRequired,
+  authenticate: PropTypes.func.isRequired,
+  updateUsername: PropTypes.func.isRequired,
+  updatePassword: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  showCancel: PropTypes.bool.isRequired,
+  username: PropTypes.string.isRequired,
+  password: PropTypes.string.isRequired,
+  submitting: PropTypes.bool.isRequired,
+  failure: PropTypes.bool.isRequired,
 };
 
 export default Main;

--- a/src/components/MarketingLink/MarketingLink.js
+++ b/src/components/MarketingLink/MarketingLink.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -24,7 +25,7 @@ class MarketingLink extends React.PureComponent {
 }
 
 MarketingLink.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 export default MarketingLink;

--- a/src/components/MaterialIcon/MaterialIcon.js
+++ b/src/components/MaterialIcon/MaterialIcon.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled, {keyframes} from 'styled-components';
 
@@ -60,11 +61,11 @@ class MaterialIcon extends React.PureComponent {
 }
 
 MaterialIcon.propTypes = {
-  icon: React.PropTypes.string.isRequired,
-  className: React.PropTypes.string,
-  size: React.PropTypes.number,
-  title: React.PropTypes.string,
-  rotate: React.PropTypes.oneOf(['left', 'right'])
+  icon: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  size: PropTypes.number,
+  title: PropTypes.string,
+  rotate: PropTypes.oneOf(['left', 'right'])
 };
 
 MaterialIcon.defaultProps = {

--- a/src/components/MessageForm/Dialog.js
+++ b/src/components/MessageForm/Dialog.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import ModalDialog from '../ModalDialog';
@@ -28,9 +29,9 @@ const Dialog = props => {
 };
 
 Dialog.propTypes = {
-  heading: React.PropTypes.string.isRequired,
-  message: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired
+  heading: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired
 };
 
 export default Dialog;

--- a/src/components/MessageForm/MessageForm.js
+++ b/src/components/MessageForm/MessageForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import H1 from '../H1';
@@ -68,11 +69,11 @@ class MessageForm extends React.Component {
 }
 
 MessageForm.propTypes = {
-  sent: React.PropTypes.bool.isRequired,
-  commitFailed: React.PropTypes.bool.isRequired,
-  handleSubmit: React.PropTypes.func.isRequired,
-  resetMessageForm: React.PropTypes.func.isRequired,
-  confirmSaveMessageSuccess: React.PropTypes.func.isRequired,
+  sent: PropTypes.bool.isRequired,
+  commitFailed: PropTypes.bool.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  resetMessageForm: PropTypes.func.isRequired,
+  confirmSaveMessageSuccess: PropTypes.func.isRequired,
 };
 
 export default reduxForm({

--- a/src/components/MessageList/MessageHeader.js
+++ b/src/components/MessageList/MessageHeader.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import dates from '../../util/dates';
@@ -24,7 +25,7 @@ const MessageHeader = props => (
 
 MessageHeader.propTypes = {
   item: MessageShape.isRequired,
-  selected: React.PropTypes.bool.isRequired
+  selected: PropTypes.bool.isRequired
 };
 
 export default MessageHeader;

--- a/src/components/MessageList/MessageList.js
+++ b/src/components/MessageList/MessageList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import MessageShape from './MessageShape';
 import MessagesWrapper from './MessagesWrapper';
 import Message from './Message';

--- a/src/components/MessageList/MessageShape.js
+++ b/src/components/MessageList/MessageShape.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
   key: PropTypes.string.isRequired,

--- a/src/components/MessagePage/MessagePage.js
+++ b/src/components/MessagePage/MessagePage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Content from './Content';
 import VerticalHeaderLayout from '../VerticalHeaderLayout';
@@ -20,11 +21,11 @@ const MessagePage = props => (
 );
 
 MessagePage.propTypes = {
-  sent: React.PropTypes.bool.isRequired,
-  commitFailed: React.PropTypes.bool.isRequired,
-  saveMessage: React.PropTypes.func.isRequired,
-  resetMessageForm: React.PropTypes.func.isRequired,
-  confirmSaveMessageSuccess: React.PropTypes.func.isRequired,
+  sent: PropTypes.bool.isRequired,
+  commitFailed: PropTypes.bool.isRequired,
+  saveMessage: PropTypes.func.isRequired,
+  resetMessageForm: PropTypes.func.isRequired,
+  confirmSaveMessageSuccess: PropTypes.func.isRequired,
 };
 
 export default MessagePage;

--- a/src/components/ModalDialog/ModalDialog.js
+++ b/src/components/ModalDialog/ModalDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Mask from './Mask';
 import Content from './Content';
 

--- a/src/components/MonthDropdown/MonthDropdown.js
+++ b/src/components/MonthDropdown/MonthDropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import Dropdown from '../Dropdown';
@@ -86,10 +87,10 @@ const MonthDropdown = props => (
 );
 
 MonthDropdown.propTypes = {
-  className: React.PropTypes.string,
-  value: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  readOnly: React.PropTypes.bool,
+  className: PropTypes.string,
+  value: PropTypes.number,
+  onChange: PropTypes.func,
+  readOnly: PropTypes.bool,
 };
 
 export default MonthDropdown;

--- a/src/components/MovementDeleteConfirmationDialog/MovementDeleteConfirmationDialog.js
+++ b/src/components/MovementDeleteConfirmationDialog/MovementDeleteConfirmationDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 import Button from '../Button';
 import ModalDialog from '../ModalDialog';

--- a/src/components/MovementList/Action.js
+++ b/src/components/MovementList/Action.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import MaterialIcon from '../MaterialIcon';
 import styled from 'styled-components';
 

--- a/src/components/MovementList/AssociatedMovement.js
+++ b/src/components/MovementList/AssociatedMovement.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MovementDetails from './MovementDetails';
@@ -94,14 +95,14 @@ class AssociatedMovement extends React.PureComponent {
 }
 
 AssociatedMovement.propTypes = {
-  movementType: React.PropTypes.oneOf(['departure', 'arrival']),
-  movementKey: React.PropTypes.string.isRequired,
-  isHomeBase: React.PropTypes.bool.isRequired,
-  associatedMovement: React.PropTypes.object,
-  oldestMovementDate: React.PropTypes.string.isRequired,
-  loading: React.PropTypes.bool.isRequired,
-  createMovementFromMovement: React.PropTypes.func.isRequired,
-  loadMovements: React.PropTypes.func.isRequired
+  movementType: PropTypes.oneOf(['departure', 'arrival']),
+  movementKey: PropTypes.string.isRequired,
+  isHomeBase: PropTypes.bool.isRequired,
+  associatedMovement: PropTypes.object,
+  oldestMovementDate: PropTypes.string.isRequired,
+  loading: PropTypes.bool.isRequired,
+  createMovementFromMovement: PropTypes.func.isRequired,
+  loadMovements: PropTypes.func.isRequired
 };
 
 export default AssociatedMovement;

--- a/src/components/MovementList/DetailsBox.js
+++ b/src/components/MovementList/DetailsBox.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -35,7 +36,7 @@ class DetailsBox extends React.PureComponent {
 }
 
 DetailsBox.propTypes = {
-  label: React.PropTypes.string
+  label: PropTypes.string
 };
 
 export default DetailsBox;

--- a/src/components/MovementList/HomeBaseIcon.js
+++ b/src/components/MovementList/HomeBaseIcon.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -58,9 +59,9 @@ class HomeBaseIcon extends React.PureComponent {
 }
 
 HomeBaseIcon.propTypes = {
-  className: React.PropTypes.string,
-  isHomeBase: React.PropTypes.bool.isRequired,
-  showText: React.PropTypes.bool
+  className: PropTypes.string,
+  isHomeBase: PropTypes.bool.isRequired,
+  showText: PropTypes.bool
 };
 
 export default HomeBaseIcon;

--- a/src/components/MovementList/Movement.js
+++ b/src/components/MovementList/Movement.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import MovementHeader from './MovementHeader';
 import MovementDetails from './MovementDetails';
@@ -154,7 +155,7 @@ Movement.propTypes = {
     homeBase: PropTypes.objectOf(PropTypes.bool)
   }).isRequired,
   oldestMovementDate: PropTypes.string.isRequired,
-  loadMovements: React.PropTypes.func.isRequired,
+  loadMovements: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import {getLabel as getFlightTypeLabel} from '../../util/flightTypes';

--- a/src/components/MovementList/MovementField.js
+++ b/src/components/MovementList/MovementField.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -32,9 +33,9 @@ class MovementField extends React.PureComponent {
 }
 
 MovementField.propTypes = {
-  label: React.PropTypes.string.isRequired,
-  value: React.PropTypes.any,
-  defaultValue: React.PropTypes.any,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.any,
+  defaultValue: PropTypes.any,
 };
 
 MovementField.defaultProps = {

--- a/src/components/MovementList/MovementGroup.js
+++ b/src/components/MovementList/MovementGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import styled from 'styled-components';
 import Movement from './Movement';
 import { isLocked } from '../../util/movements.js';
@@ -79,7 +80,7 @@ MovementGroup.propTypes = {
     homeBase: PropTypes.objectOf(PropTypes.bool)
   }).isRequired,
   oldestMovementDate: PropTypes.string,
-  loadMovements: React.PropTypes.func.isRequired,
+  loadMovements: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/MovementList/MovementHeader.js
+++ b/src/components/MovementList/MovementHeader.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import Action from './Action';

--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Predicates from './Predicates';
 import MovementGroup from './MovementGroup';
 import LoadingInfo from './LoadingInfo';
@@ -158,7 +159,7 @@ MovementList.propTypes = {
   deleteConfirmation: PropTypes.object,
   deleteItem: PropTypes.func.isRequired,
   hideDeleteConfirmationDialog: PropTypes.func.isRequired,
-  showDeleteConfirmationDialog: React.PropTypes.func.isRequired,
+  showDeleteConfirmationDialog: PropTypes.func.isRequired,
   onEdit: PropTypes.func,
   createMovementFromMovement: PropTypes.func.isRequired,
   lockDate: PropTypes.object.isRequired,

--- a/src/components/MovementsPage/MovementsPage.js
+++ b/src/components/MovementsPage/MovementsPage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Content from './Content';
 import MovementList from '../../containers/MovementListContainer';
@@ -23,7 +24,7 @@ class MovementsPage extends Component {
 }
 
 MovementsPage.propTypes = {
-  loadLockDate: React.PropTypes.func.isRequired,
+  loadLockDate: PropTypes.func.isRequired,
 };
 
 export default MovementsPage;

--- a/src/components/ReportForm/ReportForm.js
+++ b/src/components/ReportForm/ReportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import Input from '../Input';
@@ -83,16 +84,16 @@ const ReportForm = props => {
 };
 
 ReportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  children: React.PropTypes.node,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
-    month: React.PropTypes.number,
+  disabled: PropTypes.bool,
+  children: PropTypes.node,
+  date: PropTypes.shape({
+    year: PropTypes.number,
+    month: PropTypes.number,
   }),
-  parameters: React.PropTypes.object,
-  withMonth: React.PropTypes.bool,
-  setDate: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  parameters: PropTypes.object,
+  withMonth: PropTypes.bool,
+  setDate: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 ReportForm.defaultProps = {

--- a/src/components/SingleSelect/Item.js
+++ b/src/components/SingleSelect/Item.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import Button from './Button';
@@ -28,13 +29,13 @@ const Item = props => (
 );
 
 Item.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  label: React.PropTypes.string.isRequired,
-  description: React.PropTypes.string,
-  selected: React.PropTypes.bool,
-  widthPercentage: React.PropTypes.number,
-  orientation: React.PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
-  onClick: React.PropTypes.func.isRequired
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  selected: PropTypes.bool,
+  widthPercentage: PropTypes.number,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default Item;

--- a/src/components/SingleSelect/SingleSelect.js
+++ b/src/components/SingleSelect/SingleSelect.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Wrapper from './Wrapper';
 import Item from './Item';
 

--- a/src/components/StartPage/EntryPoints.js
+++ b/src/components/StartPage/EntryPoints.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import ImageButton from '../ImageButton';
@@ -42,7 +43,7 @@ class EntryPoints extends React.PureComponent {
 }
 
 EntryPoints.propTypes = {
-  admin: React.PropTypes.bool,
+  admin: PropTypes.bool,
 };
 
 export default EntryPoints;

--- a/src/components/StartPage/Header.js
+++ b/src/components/StartPage/Header.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import LoginInfo from './LoginInfo';
@@ -34,9 +35,9 @@ class Header extends React.PureComponent {
 }
 
 Header.propTypes = {
-  auth: React.PropTypes.object.isRequired,
-  logout: React.PropTypes.func.isRequired,
-  showLogin: React.PropTypes.func.isRequired,
+  auth: PropTypes.object.isRequired,
+  logout: PropTypes.func.isRequired,
+  showLogin: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/StartPage/LoginInfo.js
+++ b/src/components/StartPage/LoginInfo.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MaterialIcon from '../MaterialIcon';
@@ -40,15 +41,15 @@ class LoginInfo extends React.PureComponent {
 }
 
 LoginInfo.propTypes = {
-  className: React.PropTypes.string,
-  auth: React.PropTypes.shape({
-    authenticated: React.PropTypes.bool.isRequired,
-    data: React.PropTypes.shape({
-      uid: React.PropTypes.string
+  className: PropTypes.string,
+  auth: PropTypes.shape({
+    authenticated: PropTypes.bool.isRequired,
+    data: PropTypes.shape({
+      uid: PropTypes.string
     })
   }).isRequired,
-  logout: React.PropTypes.func.isRequired,
-  showLogin: React.PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
+  showLogin: PropTypes.func.isRequired,
 };
 
 export default LoginInfo;

--- a/src/components/StartPage/Main.js
+++ b/src/components/StartPage/Main.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import MarketingLink from '../MarketingLink';
@@ -24,7 +25,7 @@ class Main extends React.PureComponent {
 }
 
 Main.propTypes = {
-  admin: React.PropTypes.bool,
+  admin: PropTypes.bool,
 };
 
 export default Main;

--- a/src/components/StartPage/StartPage.js
+++ b/src/components/StartPage/StartPage.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Header from './Header';
 import Main from './Main';
@@ -16,9 +17,9 @@ class StartPage extends React.PureComponent {
 }
 
 StartPage.propTypes = {
-  auth: React.PropTypes.object.isRequired,
-  logout: React.PropTypes.func.isRequired,
-  showLogin: React.PropTypes.func.isRequired,
+  auth: PropTypes.object.isRequired,
+  logout: PropTypes.func.isRequired,
+  showLogin: PropTypes.func.isRequired,
 };
 
 export default StartPage;

--- a/src/components/TimeField/NumberBlock.js
+++ b/src/components/TimeField/NumberBlock.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import NumberBlockWrapper from './NumberBlockWrapper';
 import Button from './Button';
@@ -80,8 +81,8 @@ class NumberBlock extends React.Component {
 }
 
 NumberBlock.propTypes = {
-  value: React.PropTypes.number.isRequired,
-  onChange: React.PropTypes.func.isRequired,
+  value: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default NumberBlock;

--- a/src/components/TimeField/TimeField.js
+++ b/src/components/TimeField/TimeField.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { parse, normalize } from '../../util/time.js';
 import Wrapper from './Wrapper';
 import NumberBlock from './NumberBlock';

--- a/src/components/UserDropdown/Option.js
+++ b/src/components/UserDropdown/Option.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -23,9 +24,9 @@ const Option = props => (
 );
 
 Option.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  memberNr: React.PropTypes.string.isRequired,
-  focussed: React.PropTypes.bool
+  name: PropTypes.string.isRequired,
+  memberNr: PropTypes.string.isRequired,
+  focussed: PropTypes.bool
 };
 
 export default Option;

--- a/src/components/UserDropdown/UserDropdown.js
+++ b/src/components/UserDropdown/UserDropdown.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dropdown from '../Dropdown';
 import Option from './Option';
@@ -53,12 +54,12 @@ const UserDropdown = props => (
 );
 
 UserDropdown.propTypes = {
-  value: React.PropTypes.string.isRequired,
-  users: React.PropTypes.object.isRequired,
-  readOnly: React.PropTypes.bool,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+  users: PropTypes.object.isRequired,
+  readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
 };
 
 export default UserDropdown;

--- a/src/components/UserImportForm/UserImportForm.js
+++ b/src/components/UserImportForm/UserImportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import CsvImportForm, { Example } from '../CsvImportForm';
 import P from '../P';
@@ -43,14 +44,14 @@ const UserImportForm = props => {
 };
 
 UserImportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  importInProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
-  closeDoneDialog: React.PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  importInProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
+  closeDoneDialog: PropTypes.func.isRequired,
 };
 
 export default UserImportForm;

--- a/src/components/VerticalHeaderLayout/Content.js
+++ b/src/components/VerticalHeaderLayout/Content.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -17,7 +18,7 @@ class Content extends React.PureComponent {
 }
 
 Content.propTypes = {
-  children: React.PropTypes.element.isRequired
+  children: PropTypes.element.isRequired
 };
 
 export default Content;

--- a/src/components/VerticalHeaderLayout/VerticalHeaderLayout.js
+++ b/src/components/VerticalHeaderLayout/VerticalHeaderLayout.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Header from './Header';
 import Content from './Content';
@@ -15,7 +16,7 @@ class VerticalHeaderLayout extends React.PureComponent {
 }
 
 VerticalHeaderLayout.propTypes = {
-  children: React.PropTypes.element.isRequired
+  children: PropTypes.element.isRequired
 };
 
 export default VerticalHeaderLayout;

--- a/src/components/WizardBreadcrumbs/WizardBreadcrumbs.js
+++ b/src/components/WizardBreadcrumbs/WizardBreadcrumbs.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.nav`

--- a/src/components/WizardNavigation/WizardNavigation.js
+++ b/src/components/WizardNavigation/WizardNavigation.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import Button from '../Button';
 

--- a/src/components/YearlySummaryReportForm/YearlySummaryReportForm.js
+++ b/src/components/YearlySummaryReportForm/YearlySummaryReportForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReportForm from '../ReportForm';
 import Description from './Description';
@@ -15,12 +16,12 @@ const YearlySummaryReportForm = props => (
 );
 
 YearlySummaryReportForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
+  disabled: PropTypes.bool,
+  date: PropTypes.shape({
+    year: PropTypes.number,
   }),
-  setDate: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  setDate: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 export default YearlySummaryReportForm;

--- a/src/components/wizards/ArrivalWizard/ArrivalWizard.js
+++ b/src/components/wizards/ArrivalWizard/ArrivalWizard.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import MovementWizard from '../MovementWizard';
 import AircraftPage from '../pages/AircraftPage';
@@ -54,22 +55,22 @@ const ArrivalWizard = props => (
 );
 
 ArrivalWizard.propTypes = {
-  wizard: React.PropTypes.object.isRequired,
-  match: React.PropTypes.shape({
-    params: React.PropTypes.object.isRequired
+  wizard: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.object.isRequired
   }).isRequired,
-  initNewMovement: React.PropTypes.func.isRequired,
-  initNewMovementFromMovement: React.PropTypes.func.isRequired,
-  editMovement: React.PropTypes.func.isRequired,
-  nextPage: React.PropTypes.func.isRequired,
-  previousPage: React.PropTypes.func.isRequired,
-  cancel: React.PropTypes.func.isRequired,
-  finish: React.PropTypes.func.isRequired,
-  saveMovement: React.PropTypes.func.isRequired,
-  unsetCommitError: React.PropTypes.func.isRequired,
-  destroyForm: React.PropTypes.func.isRequired,
-  showDialog: React.PropTypes.func.isRequired,
-  hideDialog: React.PropTypes.func.isRequired,
+  initNewMovement: PropTypes.func.isRequired,
+  initNewMovementFromMovement: PropTypes.func.isRequired,
+  editMovement: PropTypes.func.isRequired,
+  nextPage: PropTypes.func.isRequired,
+  previousPage: PropTypes.func.isRequired,
+  cancel: PropTypes.func.isRequired,
+  finish: PropTypes.func.isRequired,
+  saveMovement: PropTypes.func.isRequired,
+  unsetCommitError: PropTypes.func.isRequired,
+  destroyForm: PropTypes.func.isRequired,
+  showDialog: PropTypes.func.isRequired,
+  hideDialog: PropTypes.func.isRequired,
 };
 
 export default ArrivalWizard;

--- a/src/components/wizards/ArrivalWizard/Finish/Finish.js
+++ b/src/components/wizards/ArrivalWizard/Finish/Finish.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { getFromItemKey } from '../../../../util/reference-number';
 import Wrapper from './Wrapper';
 import Heading from './Heading';

--- a/src/components/wizards/ArrivalWizard/pages/DepartureArrivalPage.js
+++ b/src/components/wizards/ArrivalWizard/pages/DepartureArrivalPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderAerodromeDropdown, renderDateField, renderTimeField, renderIncrementationField } from '../../renderField';

--- a/src/components/wizards/ArrivalWizard/pages/FlightPage.js
+++ b/src/components/wizards/ArrivalWizard/pages/FlightPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderSingleSelect, renderTextArea } from '../../renderField';

--- a/src/components/wizards/ArrivalWizard/pages/PassengerPage.js
+++ b/src/components/wizards/ArrivalWizard/pages/PassengerPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderIncrementationField } from '../../renderField';

--- a/src/components/wizards/DepartureWizard/CommitRequirementsDialog/CommitRequirementsDialog.js
+++ b/src/components/wizards/DepartureWizard/CommitRequirementsDialog/CommitRequirementsDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ModalDialog from '../../../ModalDialog';
 import Heading from './Heading';
 import Items from './Items';

--- a/src/components/wizards/DepartureWizard/DepartureWizard.js
+++ b/src/components/wizards/DepartureWizard/DepartureWizard.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import MovementWizard from '../MovementWizard';
 import AircraftPage from '../pages/AircraftPage';
@@ -60,22 +61,22 @@ const DepartureWizard = props => (
 );
 
 DepartureWizard.propTypes = {
-  wizard: React.PropTypes.object.isRequired,
-  match: React.PropTypes.shape({
-    params: React.PropTypes.object.isRequired
+  wizard: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.object.isRequired
   }).isRequired,
-  initNewMovement: React.PropTypes.func.isRequired,
-  initNewMovementFromMovement: React.PropTypes.func.isRequired,
-  editMovement: React.PropTypes.func.isRequired,
-  nextPage: React.PropTypes.func.isRequired,
-  previousPage: React.PropTypes.func.isRequired,
-  cancel: React.PropTypes.func.isRequired,
-  finish: React.PropTypes.func.isRequired,
-  showDialog: React.PropTypes.func.isRequired,
-  hideDialog: React.PropTypes.func.isRequired,
-  saveMovement: React.PropTypes.func.isRequired,
-  unsetCommitError: React.PropTypes.func.isRequired,
-  destroyForm: React.PropTypes.func.isRequired,
+  initNewMovement: PropTypes.func.isRequired,
+  initNewMovementFromMovement: PropTypes.func.isRequired,
+  editMovement: PropTypes.func.isRequired,
+  nextPage: PropTypes.func.isRequired,
+  previousPage: PropTypes.func.isRequired,
+  cancel: PropTypes.func.isRequired,
+  finish: PropTypes.func.isRequired,
+  showDialog: PropTypes.func.isRequired,
+  hideDialog: PropTypes.func.isRequired,
+  saveMovement: PropTypes.func.isRequired,
+  unsetCommitError: PropTypes.func.isRequired,
+  destroyForm: PropTypes.func.isRequired,
 };
 
 export default DepartureWizard;

--- a/src/components/wizards/DepartureWizard/Finish/Finish.js
+++ b/src/components/wizards/DepartureWizard/Finish/Finish.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import ImageButton from '../../../ImageButton';
 

--- a/src/components/wizards/DepartureWizard/pages/DepartureArrivalPage.js
+++ b/src/components/wizards/DepartureWizard/pages/DepartureArrivalPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderAerodromeDropdown, renderDateField, renderTimeField, renderDurationField } from '../../renderField';

--- a/src/components/wizards/DepartureWizard/pages/FlightPage.js
+++ b/src/components/wizards/DepartureWizard/pages/FlightPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderSingleSelect, renderTextArea } from '../../renderField';

--- a/src/components/wizards/DepartureWizard/pages/PassengerPage.js
+++ b/src/components/wizards/DepartureWizard/pages/PassengerPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../../validate';
 import { renderIncrementationField, renderSingleSelect } from '../../renderField';

--- a/src/components/wizards/FieldSet.js
+++ b/src/components/wizards/FieldSet.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -25,10 +26,10 @@ class FieldSet extends React.PureComponent {
 }
 
 FieldSet.propTypes = {
-  legend: React.PropTypes.string,
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.node),
-    React.PropTypes.node
+  legend: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
   ])
 };
 

--- a/src/components/wizards/MovementWizard.js
+++ b/src/components/wizards/MovementWizard.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import CommitFailureDialog from '../CommitFailureDialog';
 import Centered from '../Centered';
@@ -132,39 +133,39 @@ class MovementWizard extends Component {
 }
 
 MovementWizard.propTypes = {
-  pages: React.PropTypes.arrayOf(React.PropTypes.shape({
-    component: React.PropTypes.func.isRequired,
-    label: React.PropTypes.string.isRequired,
-    dialog: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      component: React.PropTypes.func.isRequired,
-      predicate: React.PropTypes.func,
+  pages: PropTypes.arrayOf(PropTypes.shape({
+    component: PropTypes.func.isRequired,
+    label: PropTypes.string.isRequired,
+    dialog: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      component: PropTypes.func.isRequired,
+      predicate: PropTypes.func,
     })
   })).isRequired,
-  finishComponentClass: React.PropTypes.func.isRequired,
-  wizard: React.PropTypes.object.isRequired,
-  match: React.PropTypes.shape({
-    params: React.PropTypes.object.isRequired
+  finishComponentClass: PropTypes.func.isRequired,
+  wizard: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.object.isRequired
   }).isRequired,
-  newMovementLabel: React.PropTypes.string.isRequired,
-  updateMovementLabel: React.PropTypes.string.isRequired,
-  lockDateLoading: React.PropTypes.bool.isRequired,
-  locked: React.PropTypes.bool.isRequired,
-  className: React.PropTypes.string,
+  newMovementLabel: PropTypes.string.isRequired,
+  updateMovementLabel: PropTypes.string.isRequired,
+  lockDateLoading: PropTypes.bool.isRequired,
+  locked: PropTypes.bool.isRequired,
+  className: PropTypes.string,
 
-  initNewMovement: React.PropTypes.func.isRequired,
-  editMovement: React.PropTypes.func.isRequired,
-  initMovement: React.PropTypes.func,
-  nextPage: React.PropTypes.func.isRequired,
-  previousPage: React.PropTypes.func.isRequired,
-  cancel: React.PropTypes.func.isRequired,
-  finish: React.PropTypes.func.isRequired,
-  showDialog: React.PropTypes.func,
-  hideDialog: React.PropTypes.func,
-  saveMovement: React.PropTypes.func.isRequired,
-  unsetCommitError: React.PropTypes.func,
-  destroyForm: React.PropTypes.func.isRequired,
-  loadLockDate: React.PropTypes.func.isRequired,
+  initNewMovement: PropTypes.func.isRequired,
+  editMovement: PropTypes.func.isRequired,
+  initMovement: PropTypes.func,
+  nextPage: PropTypes.func.isRequired,
+  previousPage: PropTypes.func.isRequired,
+  cancel: PropTypes.func.isRequired,
+  finish: PropTypes.func.isRequired,
+  showDialog: PropTypes.func,
+  hideDialog: PropTypes.func,
+  saveMovement: PropTypes.func.isRequired,
+  unsetCommitError: PropTypes.func,
+  destroyForm: PropTypes.func.isRequired,
+  loadLockDate: PropTypes.func.isRequired,
 };
 
 export default MovementWizard;

--- a/src/components/wizards/pages/AircraftPage.js
+++ b/src/components/wizards/pages/AircraftPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../validate';
 import { renderInputField, renderAircraftDropdown } from '../renderField';

--- a/src/components/wizards/pages/PilotPage.js
+++ b/src/components/wizards/pages/PilotPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import validate from '../validate';
 import { renderInputField, renderUserDropdown } from '../renderField';

--- a/src/containers/AerodromeDropdownContainer.js
+++ b/src/containers/AerodromeDropdownContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadAerodromes } from '../modules/aerodromes';
@@ -24,13 +25,13 @@ class AerodromeDropdownContainer extends Component {
 }
 
 AerodromeDropdownContainer.propTypes = {
-  loadAerodromes: React.PropTypes.func.isRequired,
-  aerodromes: React.PropTypes.object.isRequired,
-  value: React.PropTypes.string,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  readOnly: React.PropTypes.bool,
+  loadAerodromes: PropTypes.func.isRequired,
+  aerodromes: PropTypes.object.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/containers/AerodromeImportFormContainer.js
+++ b/src/containers/AerodromeImportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initImport, selectImportFile, startImport } from '../modules/imports';
@@ -28,14 +29,14 @@ class AerodromeImportFormContainer extends React.Component {
 }
 
 AerodromeImportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  inProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  initImport: React.PropTypes.func.isRequired,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
+  initialized: PropTypes.bool.isRequired,
+  inProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  initImport: PropTypes.func.isRequired,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/AircraftDropdownContainer.js
+++ b/src/containers/AircraftDropdownContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadAircrafts } from '../modules/aircrafts';
@@ -24,13 +25,13 @@ class AircraftDropdownContainer extends Component {
 }
 
 AircraftDropdownContainer.propTypes = {
-  loadAircrafts: React.PropTypes.func.isRequired,
-  aircrafts: React.PropTypes.object.isRequired,
-  value: React.PropTypes.string,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  readOnly: React.PropTypes.bool,
+  loadAircrafts: PropTypes.func.isRequired,
+  aircrafts: PropTypes.object.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/containers/AircraftImportFormContainer.js
+++ b/src/containers/AircraftImportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initImport, selectImportFile, startImport } from '../modules/imports';
@@ -28,14 +29,14 @@ class AircraftImportFormContainer extends React.Component {
 }
 
 AircraftImportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  inProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  initImport: React.PropTypes.func.isRequired,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
+  initialized: PropTypes.bool.isRequired,
+  inProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  initImport: PropTypes.func.isRequired,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/AircraftsItemListContainer.js
+++ b/src/containers/AircraftsItemListContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { changeNewItem } from '../modules/ui/settings/aircrafts';
@@ -24,12 +25,12 @@ class AircraftsItemListContainer extends React.Component {
 }
 
 AircraftsItemListContainer.propTypes = {
-  items: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-  newItem: React.PropTypes.string.isRequired,
-  loadAircraftSettings: React.PropTypes.func.isRequired,
-  changeNewItem: React.PropTypes.func.isRequired,
-  addItem: React.PropTypes.func.isRequired,
-  removeItem: React.PropTypes.func.isRequired,
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  newItem: PropTypes.string.isRequired,
+  loadAircraftSettings: PropTypes.func.isRequired,
+  changeNewItem: PropTypes.func.isRequired,
+  addItem: PropTypes.func.isRequired,
+  removeItem: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/containers/AirstatReportFormContainer.js
+++ b/src/containers/AirstatReportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initReport, setReportDate, setReportParameter, generateReport } from '../modules/reports';
@@ -24,17 +25,17 @@ class AirstatReportFormContainer extends React.Component {
 }
 
 AirstatReportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
-    month: React.PropTypes.number,
+  initialized: PropTypes.bool.isRequired,
+  date: PropTypes.shape({
+    year: PropTypes.number,
+    month: PropTypes.number,
   }),
-  internal: React.PropTypes.bool,
-  generationInProgress: React.PropTypes.bool,
-  initReport: React.PropTypes.func.isRequired,
-  setDate: React.PropTypes.func.isRequired,
-  setInternal: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  internal: PropTypes.bool,
+  generationInProgress: PropTypes.bool,
+  initReport: PropTypes.func.isRequired,
+  setDate: PropTypes.func.isRequired,
+  setInternal: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/ArrivalFinishContainer.js
+++ b/src/containers/ArrivalFinishContainer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadAircraftSettings } from '../modules/settings/aircrafts';
 import { createMovementFromMovement } from '../modules/ui/movements';

--- a/src/containers/LandingsReportFormContainer.js
+++ b/src/containers/LandingsReportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initReport, setReportDate, generateReport } from '../modules/reports';
@@ -22,15 +23,15 @@ class LandingsReportFormContainer extends React.Component {
 }
 
 LandingsReportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
-    month: React.PropTypes.number,
+  initialized: PropTypes.bool.isRequired,
+  date: PropTypes.shape({
+    year: PropTypes.number,
+    month: PropTypes.number,
   }),
-  generationInProgress: React.PropTypes.bool,
-  initReport: React.PropTypes.func.isRequired,
-  setDate: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  generationInProgress: PropTypes.bool,
+  initReport: PropTypes.func.isRequired,
+  setDate: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/UserDropdownContainer.js
+++ b/src/containers/UserDropdownContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { loadUsers } from '../modules/users';
@@ -24,13 +25,13 @@ class UserDropdownContainer extends Component {
 }
 
 UserDropdownContainer.propTypes = {
-  loadUsers: React.PropTypes.func.isRequired,
-  users: React.PropTypes.object.isRequired,
-  value: React.PropTypes.string,
-  onChange: React.PropTypes.func.isRequired,
-  onFocus: React.PropTypes.func.isRequired,
-  onBlur: React.PropTypes.func.isRequired,
-  readOnly: React.PropTypes.bool,
+  loadUsers: PropTypes.func.isRequired,
+  users: PropTypes.object.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/containers/UserImportFormContainer.js
+++ b/src/containers/UserImportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initImport, selectImportFile, startImport } from '../modules/imports';
@@ -28,14 +29,14 @@ class UserImportFormContainer extends React.Component {
 }
 
 UserImportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  inProgress: React.PropTypes.bool.isRequired,
-  importDone: React.PropTypes.bool.isRequired,
-  importFailed: React.PropTypes.bool.isRequired,
-  selectedFile: React.PropTypes.object,
-  initImport: React.PropTypes.func.isRequired,
-  selectFile: React.PropTypes.func.isRequired,
-  startImport: React.PropTypes.func.isRequired,
+  initialized: PropTypes.bool.isRequired,
+  inProgress: PropTypes.bool.isRequired,
+  importDone: PropTypes.bool.isRequired,
+  importFailed: PropTypes.bool.isRequired,
+  selectedFile: PropTypes.object,
+  initImport: PropTypes.func.isRequired,
+  selectFile: PropTypes.func.isRequired,
+  startImport: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/YearlySummaryReportFormContainer.js
+++ b/src/containers/YearlySummaryReportFormContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { initReport, setReportDate, generateReport } from '../modules/reports';
@@ -22,14 +23,14 @@ class YearlySummaryReportFormContainer extends React.Component {
 }
 
 YearlySummaryReportFormContainer.propTypes = {
-  initialized: React.PropTypes.bool.isRequired,
-  date: React.PropTypes.shape({
-    year: React.PropTypes.number,
+  initialized: PropTypes.bool.isRequired,
+  date: PropTypes.shape({
+    year: PropTypes.number,
   }),
-  generationInProgress: React.PropTypes.bool,
-  initReport: React.PropTypes.func.isRequired,
-  setDate: React.PropTypes.func.isRequired,
-  generate: React.PropTypes.func.isRequired,
+  generationInProgress: PropTypes.bool,
+  initReport: PropTypes.func.isRequired,
+  setDate: PropTypes.func.isRequired,
+  generate: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/util/AutoLoad.js
+++ b/src/util/AutoLoad.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import isElementInViewport from '../util/isElementInViewport';
 
 export const AutoLoad = (List) => class extends Component {


### PR DESCRIPTION
React.PropTypes will be removed in React 15.5. Note that we still
can't update React, because our version of react-date-picker (4.0.8)
still uses PropTypes from the React package.