### PR TITLE
Fix bug in ModalDialog so that onBlur handler gets called again

### DIFF
--- a/src/components/ModalDialog/ModalDialog.js
+++ b/src/components/ModalDialog/ModalDialog.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import Mask from './Mask';
 import Content from './Content';
 
@@ -11,7 +11,7 @@ const handleMaskClick = onBlur => {
 
 const ModalDialog = props => (
   <div>
-    <Mask onClick={handleMaskClick.bind(props.onBlur)}/>
+    <Mask onClick={handleMaskClick.bind(null, props.onBlur)}/>
     <Content fullWidthThreshold={props.fullWidthThreshold}>{props.content}</Content>
   </div>
 );

--- a/src/components/ModalDialog/ModalDialog.spec.js
+++ b/src/components/ModalDialog/ModalDialog.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import expect from 'expect';
+import { ThemeProvider } from 'styled-components';
+import ModalDialog from './ModalDialog';
+import Utils from '../../../test/Utils';
+
+describe('components', () => {
+  describe('ModalDialog', () => {
+    it('renders given content', () => {
+      const content = <div>My test content</div>;
+      const modalDialog = (
+        <ThemeProvider theme={{}}>
+          <ModalDialog content={content}/>
+        </ThemeProvider>
+      );
+
+      const component = TestUtils.renderIntoDocument(modalDialog);
+      const element = ReactDOM.findDOMNode(component);
+
+      const contentWrapper = element.childNodes[1];
+      const contentNode = contentWrapper.childNodes[0];
+
+      expect(contentNode.innerHTML).toBe('My test content');
+    });
+
+    it('calls onBlur handler on mask click', () => {
+      const handler = Utils.callTracker();
+
+      const content = <div>My test content</div>;
+      const modalDialog = (
+        <ThemeProvider theme={{}}>
+          <ModalDialog content={content} onBlur={handler}/>
+        </ThemeProvider>
+      );
+
+      const component = TestUtils.renderIntoDocument(modalDialog);
+      const element = ReactDOM.findDOMNode(component);
+
+      const mask = element.childNodes[0];
+
+      TestUtils.Simulate.click(mask);
+
+      const calls = handler.calls();
+      expect(calls.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This bug (regression) has been introduced when the ModalDialog
got refactored to use `styled-components`.