### PR TITLE
Fix escaping issues in airstat CSV export (fixes #181)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2322,6 +2322,15 @@
       "integrity": "sha512-tUTdmYzT0J8gqwmW3nzwKt7hl8AZ0HtEXk6SYgTWX2+3KNFiDVcAYNebBsjeCaGCZrZLHDy+W20voZDY7f/oeA==",
       "dev": true
     },
+    "csv-stringify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-2.0.4.tgz",
+      "integrity": "sha512-rm8JxNYXglaDKExA2KqCKY+jx8qVBSkXm8/bgw2BIyzLq1/qni/QMSPBchAkd8RGsJhMJDQ+ZxikG/Qgvck+gQ==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "4.4.2"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3445,7 +3454,7 @@
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6542,6 +6551,12 @@
         "lodash._root": "3.0.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -9219,7 +9234,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "binary-search": "^1.3.3",
     "css-loader": "^0.28.11",
     "csv-parse": "^2.1.0",
+    "csv-stringify": "^2.0.4",
     "del": "^3.0.0",
     "expect": "^22.4.3",
     "file-loader": "^1.1.11",

--- a/src/util/writeCsv.js
+++ b/src/util/writeCsv.js
@@ -1,0 +1,15 @@
+import stringify from 'csv-stringify';
+
+function writeCsv(records) {
+  return new Promise((resolve, reject) => {
+    stringify(records, function(err, csv){
+      if (err) {
+        reject(err);
+      } else {
+        resolve(csv);
+      }
+    });
+  });
+}
+
+export default writeCsv;

--- a/src/util/writeCsv.spec.js
+++ b/src/util/writeCsv.spec.js
@@ -1,0 +1,61 @@
+import expect from 'expect';
+import writeCsv from './writeCsv';
+
+describe('util', () => {
+  describe('writeCsv', () => {
+    it('should return an empty string if no records are given', () => {
+      const records = [];
+
+      return writeCsv(records).then(csv => {
+        expect(csv).toEqual('');
+      });
+    });
+
+    it('should write comma separated strings', () => {
+      const records = [
+        ['header1', 'header2'],
+        ['value1.1', 'value1.2'],
+        ['value2.1', 'value2.2'],
+      ];
+
+      const expectedCsv =
+        'header1,header2\n' +
+        'value1.1,value1.2\n' +
+        'value2.1,value2.2\n';
+
+      return writeCsv(records).then(csv => {
+        expect(csv).toEqual(expectedCsv);
+      });
+    });
+
+    it('should enclose values with commas in double quotes', () => {
+      const records = [
+        ['header1', 'header2'],
+        ['value1', 'value, with, commas'],
+      ];
+
+      const expectedCsv =
+        'header1,header2\n' +
+        'value1,"value, with, commas"\n';
+
+      return writeCsv(records).then(csv => {
+        expect(csv).toEqual(expectedCsv);
+      });
+    });
+
+    it('should enclose values with double quotes in double quotes und escape the double quotes', () => {
+      const records = [
+        ['header1', 'header2'],
+        ['value1', 'value with "double quotes"'],
+      ];
+
+      const expectedCsv =
+        'header1,header2\n' +
+        'value1,"value with ""double quotes"""\n';
+
+      return writeCsv(records).then(csv => {
+        expect(csv).toEqual(expectedCsv);
+      });
+    });
+  });
+});


### PR DESCRIPTION
There was no escaping of special chars at all in this CSV export.
Now, the package `csv-stringify` is used to write the CSV data.