### PR TITLE
Disable flight type "commercial" (#190)

### DIFF
--- a/projects/default.json
+++ b/projects/default.json
@@ -2,7 +2,6 @@
   "theme": "lszt",
   "enabledFlightTypes": [
     "private",
-    "commercial",
     "instruction"
   ]
 }

--- a/projects/lszk.json
+++ b/projects/lszk.json
@@ -43,7 +43,6 @@
   "title": "FGZO Bewegungen",
   "enabledFlightTypes": [
     "private",
-    "commercial",
     "instruction",
     "aerotow",
     "paradrop"


### PR DESCRIPTION
There are no commercial flights anymore (BAZL doesn't accept this type).