### PR TITLE
Enable root/sudo for npm in wercker build pipeline

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -8,6 +8,11 @@ dev:
         reload: true
 build:
   steps:
+    - script:
+        name: enable root/sudo for npm
+        code: |
+          # https://docs.npmjs.com/misc/config#unsafe-perm
+          npm config set unsafe-perm true
     - npm-install
     - npm-test
     - script:


### PR DESCRIPTION
Otherwise our postinstall script which runs `npm install` in our
functions directory fails with the following log message:
npm WARN lifecycle undefined~postinstall:
cannot run in wd %s %s (wd=%s) undefined cd functions && npm install /pipeline/source

Also see: https://github.com/wercker/step-npm-install/issues/14