### PR TITLE
Introduce test credentials for Flightnet authentication mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,23 @@ $ curl \
     -d '{"mode": "flightnet", "company": "<FLIGHTNET_COMPANY>", "username": "<FLIGHTNET_USERNAME>", "password": "<FLIGHTNET_PASSWORD>"}' \
     https://us-central1-<PROJECT_ID>.cloudfunctions.net/auth
 ```
+
+##### Test credentials #####
+
+For testing purposes, test credentials can be set for this mode. If test credentials are set, authentication will
+**never** be delegated to the Flightnet authentication service.
+
+Set the test credentials in the function config:
+```
+$ firebase functions:config:set auth.testcredentials.username="foo"
+$ firebase functions:config:set auth.testcredentials.password="bar"
+```
+
+Request example (`company` not needed in request body):
+```
+curl \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"mode": "flightnet", "username": "foo", "password": "bar"}' \
+    https://us-central1-<PROJECT_ID>.cloudfunctions.net/auth
+```

--- a/functions/auth/modes/flightnet/index.js
+++ b/functions/auth/modes/flightnet/index.js
@@ -1,13 +1,42 @@
 'use strict';
 
+const functions = require('firebase-functions');
 const flightnet = require('./flightnet');
 const requestHelper = require('../../util/requestHelper');
 
+const parseTestCredentials = () => {
+  const config = functions.config();
+  if (config.auth && config.auth.testcredentials) {
+    const username = config.auth.testcredentials.username;
+    const password = config.auth.testcredentials.password;
+
+    if (!username) {
+      throw new Error('Required configuration property `username` not defined in `auth.testcredentials`');
+    }
+    if (!password) {
+      throw new Error('Required configuration property `password` not defined in `auth.testcredentials`');
+    }
+
+    return {
+      username: username,
+      password: password
+    };
+  }
+  return null;
+};
+
+const testCredentials = parseTestCredentials();
+
 module.exports = req => {
-  const company = requestHelper.requireBodyProperty(req, 'company');
   const username = requestHelper.requireBodyProperty(req, 'username');
   const password = requestHelper.requireBodyProperty(req, 'password');
 
-  return flightnet.passwordCheck(company, username, password)
-    .then(success => success ? username : null)
+  if (testCredentials) {
+    const uid = testCredentials.username && password === testCredentials.password ? username : null;
+    return Promise.resolve(uid);
+  } else {
+    const company = requestHelper.requireBodyProperty(req, 'company');
+    return flightnet.passwordCheck(company, username, password)
+      .then(success => success ? username : null)
+  }
 };

--- a/wercker.yml
+++ b/wercker.yml
@@ -29,6 +29,11 @@ deploy:
 
 coverage:
   steps:
+    - script:
+        name: enable root/sudo for npm
+        code: |
+          # https://docs.npmjs.com/misc/config#unsafe-perm
+          npm config set unsafe-perm true
     - npm-install
     - script:
         code: |-


### PR DESCRIPTION
Set the function config `auth.testcredentials.username` and
`auth.testcredentials.password` and the `auth` function will
be put into a mocking mode in which it will validate all given
credentials against the test credentials (the external Flightnet
authentication service will never be called).

This enables us to write end to end tests more easily.