### PR TITLE
Fix IP authentication

### DIFF
--- a/functions/auth/modes/ip/index.js
+++ b/functions/auth/modes/ip/index.js
@@ -20,7 +20,7 @@ module.exports = req =>
     const requestIp = requestHelper.getIp(req);
     console.info('Request IP', requestIp);
     console.info('Allowed IPs', ips);
-    if (ips.includes(requestIp)) {
+    if (requestIp && ips.includes(requestIp)) {
       resolve('ipauth');
     } else {
       resolve(null);

--- a/functions/auth/util/requestHelper.js
+++ b/functions/auth/util/requestHelper.js
@@ -10,7 +10,13 @@ const requireBodyProperty = (req, property)  => {
   return value;
 };
 
-const getIp = req => req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+const getIp = req => {
+  const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+  if (ip) {
+    return ip.split(',')[0].trim();
+  }
+  return null;
+};
 
 module.exports = {
   requireBodyProperty: requireBodyProperty,

--- a/functions/auth/util/requestHelper.spec.js
+++ b/functions/auth/util/requestHelper.spec.js
@@ -48,6 +48,39 @@ describe('functions', () => {
             };
             expect(requestHelper.getIp(request)).toEqual('10.27.1.5');
           });
+
+          it('should return the first IP from the x-forwarded-for` header', () => {
+            const request = {
+              headers: {
+                'x-forwarded-for': '10.27.1.4, 10.27.1.4'
+              },
+              connection: {
+                remoteAddress: '10.27.1.5'
+              }
+            };
+            expect(requestHelper.getIp(request)).toEqual('10.27.1.4');
+          });
+
+          it('should return the first IP from remoteAddress', () => {
+            const request = {
+              headers: {
+              },
+              connection: {
+                remoteAddress: '10.27.1.4, 10.27.1.4'
+              }
+            };
+            expect(requestHelper.getIp(request)).toEqual('10.27.1.4');
+          });
+
+          it('should return null if no IP address is set', () => {
+            const request = {
+              headers: {
+              },
+              connection: {
+              }
+            };
+            expect(requestHelper.getIp(request)).toEqual(null)
+          });
         });
       });
     });


### PR DESCRIPTION
In Lommis, "109.205.200.60, 109.205.200.60" is set as request IP
-> we're using the first IP now, if multiple ones are set.