### PR TITLE
Update firebase functions dependencies (and adjust `auth` function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@ $ firebase deploy
 
 Can be called to create a custom authentication token. Has to be called via **`POST`**.
 
-You need to set the configuration properties `serviceaccount.clientemail` and `serviceaccount.privatekey`
-before you'll be able to deploy the function (and the private key needs to be wrapped in double quotes - see example
-below). You'll find the credentials for the service account in the console of your Firebase project.
-
-```
-$ firebase functions:config:set serviceaccount.clientemail="<EMAIL>"
-$ firebase functions:config:set serviceaccount.privatekey="\"-----BEGIN PRIVATE KEY-----\n<PRIVATE KEY>\n-----END PRIVATE KEY-----\n\""
-```
-
 There are two authentication modes implemented: `ip` and `flightnet`.
 
 #### Mode *ip*

--- a/functions/auth/index.js
+++ b/functions/auth/index.js
@@ -10,24 +10,10 @@ const modes = require('./modes');
 const requestHelper = require('./util/requestHelper');
 const errors = require('./util/errors');
 
-const config = functions.config();
-
-if (!config.serviceaccount || !config.serviceaccount.clientemail) {
-  throw new Error('Required configuration property `serviceaccount.clientemail` not defined');
-}
-
-if (!config.serviceaccount || !config.serviceaccount.privatekey) {
-  throw new Error('Required configuration property `serviceaccount.privatekey` not defined');
-} else if (!config.serviceaccount.privatekey.match(/^".*"$/)) {
-  throw new Error('Configuration property `serviceaccount.privatekey` must be wrapped in double quotes')
-}
-
-admin.initializeApp({
-  credential: admin.credential.cert({
-    clientEmail: config.serviceaccount.clientemail,
-    privateKey: JSON.parse(config.serviceaccount.privatekey)
-  })
-});
+// Prevent firebase from initializing twice
+try {
+  admin.initializeApp()
+} catch (e) {}
 
 const sendToken = (res, token) => {
   res.send({

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,8 +6,8 @@
   },
   "dependencies": {
     "cors": "^2.8.4",
-    "firebase-admin": "^5.12.0",
-    "firebase-functions": "^1.0.2",
+    "firebase-admin": "8.4.0",
+    "firebase-functions": "^3.5.0",
     "soap": "^0.24.0"
   },
   "private": true,


### PR DESCRIPTION
- `firebase-admin` can only be updated to v8.4.0 and not yet to the
  current release. We have to update the `firebase` dependency in the
  root folder first.
  -> see https://github.com/firebase/firebase-admin-node/issues/717
- Service account function config is not required anymore. Instead,
  we have to give the default service account the role
  "Ersteller von Dienstkonto-Tokens"
  (go to https://console.cloud.google.com/iam-admin/iam?project=<project>)