### PR TITLE
Redirect `/api/**` requests on custom domain to `api` cloud function

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,10 @@
     "public": "build",
     "ignore": [
       "firebase-rules.json"
-    ]
+    ],
+    "rewrites": [{
+      "source": "/api/**",
+      "function": "api"
+    }]
   }
 }


### PR DESCRIPTION
This way we can get the current LSZT aerodrome status via the following URL:
https://flights.lszt.ch/api/aerodrome/status
instead of:
https://us-central1-project-8979611309653332047.cloudfunctions.net/api/aerodrome/status