### PR TITLE
Fix routing of REST API resources

### DIFF
--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -13,7 +13,7 @@ try {
 
 api.use(cors)
 
-api.get('/aerodrome/status', async (req, res) => {
+api.get('(/api)?/aerodrome/status', async (req, res) => {
   const status = await fetchAerodromeStatus(admin.database())
 
   res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')


### PR DESCRIPTION
If the API is called via the hosting domain instead of over
`...cloudfunctions.net/api`, the path that reaches the API includes
the `/api` prefix. So we have to include that into the routes
optionally so that both calls work.