### PR TITLE
Use firebase@9 for deployment on wercker

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -24,7 +24,7 @@ deploy:
   steps:
     - script:
         code: |-
-          npm install -g firebase-tools
+          npm install -g firebase-tools@9
     - script:
         code: |-
           firebase use $FIREBASE_PROJECT --token $FIREBASE_TOKEN


### PR DESCRIPTION
To fix error message during deployment:
Firebase CLI v10.1.0 is incompatible with Node.js v10.24.1