### PR TITLE
Add columns `LDG_COUNT` and `GA_COUNT` to internal movement report

### DIFF
--- a/src/components/AirstatReportForm/InternalDescription.js
+++ b/src/components/AirstatReportForm/InternalDescription.js
@@ -41,6 +41,10 @@ const InternalDescription = () => (
       <Dd>Bemerkungen</Dd>
       <Dt>FEES</Dt>
       <Dd>Total der Landegebühren</Dd>
+      <Dt>LDG_COUNT</Dt>
+      <Dd>Anzahl Landungen</Dd>
+      <Dt>GA_COUNT</Dt>
+      <Dd>Anzahl Durchstarts</Dd>
     </Dl>
   </div>
 );


### PR DESCRIPTION
- Contains the number of landings and number of go arounds
- Note that if there are more than 1 landing or go around, there is inserted
  an additional "circuits" record right below the movement and the number of
  landings/GAs is set to 1 in the original movement. However, the total fees
  are only set on the original movement, but they are calculated from all the
  landings and go arounds on *both* records.

Ticket: https://app.asana.com/0/1201466020311786/1201770934104705