### PR TITLE
Set type of runway (TYPPI) "A" (asphalt) for LSPV runways

### DIFF
--- a/projects/lspv.json
+++ b/projects/lspv.json
@@ -3,8 +3,14 @@
     "name": "Wangen-Lachen",
     "ICAO": "LSPV",
     "runways": [
-      "08",
-      "26"
+      {
+        "name": "08",
+        "type": "A"
+      },
+      {
+        "name": "26",
+        "type": "A"
+      }
     ],
     "noRunwayIfHelicopter": true,
     "departureRoutes": [

--- a/projects/lszk.json
+++ b/projects/lszk.json
@@ -3,8 +3,14 @@
     "name": "Speck-Fehraltorf",
     "ICAO": "LSZK",
     "runways": [
-      "12",
-      "30"
+      {
+        "name": "12",
+        "type": "G"
+      },
+      {
+        "name": "30",
+        "type": "G"
+      }
     ],
     "departureRoutes": [
       {

--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -3,8 +3,14 @@
     "name": "Lommis",
     "ICAO": "LSZT",
     "runways": [
-      "06",
-      "24"
+      {
+        "name": "06",
+        "type": "G"
+      },
+      {
+        "name": "24",
+        "type": "G"
+      }
     ],
     "departureRoutes": [
       {

--- a/src/components/YearlySummaryReportForm/Description.js
+++ b/src/components/YearlySummaryReportForm/Description.js
@@ -24,10 +24,10 @@ const Description = () => (
     <Dl>
       <Dt>Month</Dt>
       <Dd>Der Monat</Dd>
-      <Dt>RWY{__CONF__.aerodrome.runways[0]}</Dt>
-      <Dd>Anzahl Bewegungen auf Piste {__CONF__.aerodrome.runways[0]}</Dd>
-      <Dt>RWY{__CONF__.aerodrome.runways[1]}</Dt>
-      <Dd>Anzahl Bewegungen auf Piste {__CONF__.aerodrome.runways[1]}</Dd>
+      <Dt>RWY{__CONF__.aerodrome.runways[0].name}</Dt>
+      <Dd>Anzahl Bewegungen auf Piste {__CONF__.aerodrome.runways[0].name}</Dd>
+      <Dt>RWY{__CONF__.aerodrome.runways[1].name}</Dt>
+      <Dd>Anzahl Bewegungen auf Piste {__CONF__.aerodrome.runways[1].name}</Dd>
       <Dt>PrivatePax</Dt>
       <Dd>Anzahl Passagiere bei privaten Bewegungen</Dd>
       <Dt>PrivateLocal</Dt>

--- a/src/components/wizards/validate.js
+++ b/src/components/wizards/validate.js
@@ -80,7 +80,7 @@ const config = {
   runway: {
     types: {
       required: true,
-      values: objectToArray(__CONF__.aerodrome.runways),
+      values: objectToArray(__CONF__.aerodrome.runways).map(runway => runway.name),
     },
     message: {
       departure: 'Wählen Sie hier die Pistenrichtung für den Abflug aus.',

--- a/src/containers/ArrivalFlightPageContainer.js
+++ b/src/containers/ArrivalFlightPageContainer.js
@@ -8,8 +8,8 @@ import isHelicopter from "../util/isHelicopter"
 
 const runways = objectToArray(__CONF__.aerodrome.runways)
   .map(runway => ({
-    label: runway,
-    value: runway,
+    label: runway.name,
+    value: runway.name,
   }));
 
 const arrivalRoutes = getArrivalRoutes();

--- a/src/containers/DepartureFlightPageContainer.js
+++ b/src/containers/DepartureFlightPageContainer.js
@@ -8,8 +8,8 @@ import isHelicopter from '../util/isHelicopter'
 
 const runways = objectToArray(__CONF__.aerodrome.runways)
   .map(runway => ({
-    label: runway,
-    value: runway,
+    label: runway.name,
+    value: runway.name,
   }));
 
 const departureRoutes = getDepartureRoutes();

--- a/src/util/MovementReport.js
+++ b/src/util/MovementReport.js
@@ -9,7 +9,8 @@ import ItemsArray from './ItemsArray';
 import {getAirstatType} from './flightTypes';
 import moment from 'moment';
 import writeCsv from './writeCsv';
-import isHelicopter from './isHelicopter'
+import isHelicopter from './isHelicopter';
+import objectToArray from './objectToArray';
 
 const CIRCUITS_KEY_SUFFIX = '_circuits';
 
@@ -147,7 +148,7 @@ class MovementReport {
       DATMO: movement.date.replace(/-/g, ''),
       TIMMO: movement.time.replace(/:/g, ''),
       PIMO: movement.runway,
-      TYPPI: 'G',
+      TYPPI: this.getTypeOfRunway(movement),
       DIRDE: this.getDirectionOfDeparture(movement),
       CID: __CONF__.aerodrome.ICAO,
       CDT: this.creationDate.format('YYYYMMDD'),
@@ -198,6 +199,11 @@ class MovementReport {
 
   getDirectionOfDeparture(movement) {
     return (movement.type === 'D') ? movement.departureRoute : '';
+  }
+
+  getTypeOfRunway(movement) {
+    const runway = objectToArray(__CONF__.aerodrome.runways).find(rwy => rwy.name === movement.runway);
+    return runway ? runway.type : '';
   }
 
   getMovementKey(movement) {

--- a/src/util/YearlySummaryReport.js
+++ b/src/util/YearlySummaryReport.js
@@ -42,8 +42,8 @@ class YearlySummaryReport {
     const summary = {
       Month: monthNr,
 
-      ['RWY' + __CONF__.aerodrome.runways[0]]: 0,
-      ['RWY' + __CONF__.aerodrome.runways[1]]: 0,
+      ['RWY' + __CONF__.aerodrome.runways[0].name]: 0,
+      ['RWY' + __CONF__.aerodrome.runways[1].name]: 0,
 
       PrivatePax: 0,
       PrivateLocal: 0,
@@ -152,7 +152,8 @@ class YearlySummaryReport {
       }
     }
 
-    summary.Total = summary['RWY' + __CONF__.aerodrome.runways[0]] + summary['RWY' + __CONF__.aerodrome.runways[1]];
+    summary.Total = summary['RWY' + __CONF__.aerodrome.runways[0].name] +
+      summary['RWY' + __CONF__.aerodrome.runways[1].name];
     summary.TotalCircuits = summary.PrivateCircuits + summary.InstructionCircuits;
 
     return YearlySummaryReport.header
@@ -168,8 +169,8 @@ class YearlySummaryReport {
 YearlySummaryReport.header = [
   'Month',
 
-  'RWY' + __CONF__.aerodrome.runways[0],
-  'RWY' + __CONF__.aerodrome.runways[1],
+  'RWY' + __CONF__.aerodrome.runways[0].name,
+  'RWY' + __CONF__.aerodrome.runways[1].name,
 
   'PrivatePax',
   'PrivateLocal',

--- a/tasks/processFirebaseRules.js
+++ b/tasks/processFirebaseRules.js
@@ -12,7 +12,7 @@ function newValEquals(val) {
 }
 
 function processRunway(config) {
-  return config.aerodrome.runways.map(runway => newValEquals(runway)).join(" || ");
+  return config.aerodrome.runways.map(runway => newValEquals(runway.name)).join(" || ");
 }
 
 function processDepartureRoute(config) {


### PR DESCRIPTION
Before, runway type "G" (grass) was hardcoded in the BAZL airstat
report. Now, the type needs to be defined in the project configuration.

Ticket: https://app.asana.com/0/1201466020311786/1201825174285316