### PR TITLE
Fix departure and arrival routes for LSPV

### DIFF
--- a/projects/lspv.json
+++ b/projects/lspv.json
@@ -15,25 +15,25 @@
     "noRunwayIfHelicopter": true,
     "departureRoutes": [
       {
-        "name": "E",
-        "label": "E",
+        "name": "O",
+        "label": "Ost",
         "condition": "notHelicopter"
       },
       {
         "name": "W",
-        "label": "W",
+        "label": "West",
         "condition": "notHelicopter"
       },
       {
         "name": "S",
-        "label": "S",
+        "label": "Süd",
         "condition": "helicopter"
       }
     ],
     "arrivalRoutes": [
       {
         "name": "S",
-        "label": "S"
+        "label": "Süd"
       }
     ],
     "landingFees": {


### PR DESCRIPTION
- 'E' (east) replaced with 'O' (Ost)
- Use full word for labels ("Ost", "West", "Süd")