### PR TITLE
Fix bug where time fields were set to 0 when lost focus w/o changes

### DIFF
--- a/src/components/TimeField/NumberBlock.js
+++ b/src/components/TimeField/NumberBlock.js
@@ -24,7 +24,7 @@ class NumberBlock extends React.Component {
         <Input
           type="text"
           value={this.state.editingValue !== null ? this.state.editingValue : this.formatTwoDigit(this.props.value)}
-          onFocus={e => e.target.select()}
+          onFocus={this.handleFocus.bind(this)}
           onChange={this.handleChange.bind(this)}
           onBlur={this.handleBlur.bind(this)}
           maxLength={2}
@@ -37,6 +37,13 @@ class NumberBlock extends React.Component {
         >-</Button>
       </NumberBlockWrapper>
     );
+  }
+
+  handleFocus(e) {
+    e.target.select();
+    this.setState({
+      editingValue: e.target.value
+    });
   }
 
   handleChange(e) {


### PR DESCRIPTION
In this case, `state.editingValue` was not set, because `handleChange`
was never called. As a result, the field was set to 0 in `handleBlur`.