### PR TITLE
Improve matching of associated movement in movement list

### DIFF
--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -4,7 +4,8 @@
       ".read": "auth !== null",
       ".indexOn": [
         "dateTime",
-        "negativeTimestamp"
+        "negativeTimestamp",
+        "immatriculation"
       ],
       "$departure_id": {
         ".write": "auth !== null && (!root.child('settings/lockDate').exists() || (!data.exists() && newData.exists() && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && !newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24 && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24))",
@@ -72,7 +73,8 @@
       ".read": "auth !== null",
       ".indexOn": [
         "dateTime",
-        "negativeTimestamp"
+        "negativeTimestamp",
+        "immatriculation"
       ],
       "$arrival_id": {
         ".write": "auth !== null && (!root.child('settings/lockDate').exists() || (!data.exists() && newData.exists() && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && !newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24) || (data.exists() && newData.exists() && data.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24 && newData.child('negativeTimestamp').val() * -1 > root.child('settings/lockDate').val() + 1000 * 60 * 60 * 24))",

--- a/src/components/MovementList/AssociatedMovement.js
+++ b/src/components/MovementList/AssociatedMovement.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
+import MaterialIcon from '../MaterialIcon';
 import MovementDetails from './MovementDetails';
 import Action from './Action';
 import {ACTION_LABELS} from './labels';
@@ -33,11 +34,10 @@ class AssociatedMovement extends React.PureComponent {
   constructor(props) {
     super(props);
     this.handleCreateMovement = this.handleCreateMovement.bind(this);
-    this.handleLoadMovements = this.handleLoadMovements.bind(this);
   }
 
   render() {
-    const {movementType, associatedMovement, oldestMovementDate} = this.props;
+    const {movementType, associatedMovement} = this.props;
 
     let label;
     let text;
@@ -46,40 +46,38 @@ class AssociatedMovement extends React.PureComponent {
       label = 'Zugeordnete Ankunft';
       text = associatedMovement
         ? 'Die folgende Ankunft wurde diesem Abflug automatisch zugeordnet:'
-        : `Es konnte keine Ankunft zugeordnet werden. Es wurden alle Bewegungen seit ${oldestMovementDate} berücksichtigt.`
+        : associatedMovement === null
+          ? 'Es konnte keine Ankunft zugeordnet werden.'
+          : null;
     } else {
       label = 'Zugeordneter Abflug';
       text = associatedMovement
         ? 'Der folgende Abflug wurde dieser Ankunft automatisch zugeordnet:'
-        : `Es konnte kein Abflug zugeordnet werden. Es wurden alle Bewegungen seit ${oldestMovementDate} berücksichtigt.`
+        : associatedMovement === null
+          ? 'Es konnte kein Abflug zugeordnet werden.'
+          : null;
     }
 
     return (
       <Wrapper>
         <div>
           <Label>{label}</Label>
-          <div>{text}</div>
-          {associatedMovement && <StyledDetails data={associatedMovement} isHomeBase={this.props.isHomeBase}/>}
-          {!associatedMovement && (
-            <ActionsContainer>
-              <ActionContainer>
-                <Action
-                  label={ACTION_LABELS[movementType].label}
-                  icon={ACTION_LABELS[movementType].icon}
-                  onClick={this.handleCreateMovement}
-                />
-              </ActionContainer>
-              <ActionContainer>
-                <Action
-                  label="Ältere Bewegungen laden"
-                  icon={this.props.loading ? 'sync' : 'history'}
-                  onClick={this.handleLoadMovements}
-                  disabled={this.props.loading}
-                  rotateIcon={this.props.loading ? 'left' : null}
-                />
-              </ActionContainer>
-            </ActionsContainer>
-          )}
+          {text && <div>{text}</div>}
+          {associatedMovement
+            ? <StyledDetails data={associatedMovement} isHomeBase={this.props.isHomeBase}/>
+            : associatedMovement === undefined
+              ? <MaterialIcon icon="sync" rotate="left"/>
+              : (
+                <ActionsContainer>
+                  <ActionContainer>
+                    <Action
+                      label={ACTION_LABELS[movementType].label}
+                      icon={ACTION_LABELS[movementType].icon}
+                      onClick={this.handleCreateMovement}
+                    />
+                  </ActionContainer>
+                </ActionsContainer>
+              )}
         </div>
       </Wrapper>
     )
@@ -88,10 +86,6 @@ class AssociatedMovement extends React.PureComponent {
   handleCreateMovement() {
     this.props.createMovementFromMovement(this.props.movementType, this.props.movementKey);
   }
-
-  handleLoadMovements() {
-    this.props.loadMovements();
-  }
 }
 
 AssociatedMovement.propTypes = {
@@ -99,10 +93,8 @@ AssociatedMovement.propTypes = {
   movementKey: PropTypes.string.isRequired,
   isHomeBase: PropTypes.bool.isRequired,
   associatedMovement: PropTypes.object,
-  oldestMovementDate: PropTypes.string.isRequired,
   loading: PropTypes.bool.isRequired,
-  createMovementFromMovement: PropTypes.func.isRequired,
-  loadMovements: PropTypes.func.isRequired
+  createMovementFromMovement: PropTypes.func.isRequired
 };
 
 export default AssociatedMovement;

--- a/src/components/MovementList/Movement.js
+++ b/src/components/MovementList/Movement.js
@@ -9,10 +9,10 @@ import Action from './Action';
 const Wrapper = styled.div`
   background-color: #fbfbfb;
   box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
-  
+
   ${props => props.selected && `
     margin: 20px -10px 20px -10px;
-    
+
     @media (max-width: 768px) {
       margin: 10px -3px 10px -3px;
     }
@@ -40,43 +40,11 @@ class Movement extends React.PureComponent {
     this.handleEditClick = this.handleEditClick.bind(this);
   }
 
-  getAssociatedMovement(movementType, isHomeBase, preceding, subsequent) {
-    if (movementType === 'departure') {
-      if (isHomeBase) {
-        if (subsequent && subsequent.type === 'arrival') {
-          return subsequent;
-        }
-      } else {
-        if (preceding && preceding.type === 'arrival') {
-          return preceding;
-        }
-      }
-    } else if (movementType === 'arrival') {
-      if (isHomeBase) {
-        if (preceding && preceding.type === 'departure') {
-          return preceding;
-        }
-      } else {
-        if (subsequent && subsequent.type === 'departure') {
-          return subsequent;
-        }
-      }
-    }
-    return null;
-  }
-
   render() {
     const props = this.props;
 
     const isHomeBase = props.aircraftSettings.club[props.data.immatriculation] === true
       || props.aircraftSettings.homeBase[props.data.immatriculation] === true;
-
-    const associatedMovement = this.getAssociatedMovement(
-      props.data.type,
-      isHomeBase,
-      props.preceding,
-      props.subsequent
-    );
 
     return (
       <Wrapper selected={props.selected}>
@@ -88,14 +56,13 @@ class Movement extends React.PureComponent {
           createMovementFromMovement={props.createMovementFromMovement}
           onDelete={props.onDelete}
           locked={props.locked}
-          hasAssociatedMovement={!!associatedMovement}
+          associatedMovement={props.associatedMovement}
           isHomeBase={isHomeBase}
         />
         {props.selected && (
           <div>
             <StyledMovementDetails
               data={props.data}
-              associations={props.associations}
               locked={props.locked}
               isHomeBase={isHomeBase}
             />
@@ -112,10 +79,8 @@ class Movement extends React.PureComponent {
               movementType={props.data.type}
               movementKey={props.data.key}
               isHomeBase={isHomeBase}
-              oldestMovementDate={props.oldestMovementDate}
-              associatedMovement={associatedMovement}
+              associatedMovement={props.associatedMovement}
               createMovementFromMovement={props.createMovementFromMovement}
-              loadMovements={props.loadMovements}
               loading={props.loading}
             />
           </div>
@@ -141,8 +106,7 @@ class Movement extends React.PureComponent {
 
 Movement.propTypes = {
   data: PropTypes.object.isRequired,
-  preceding: PropTypes.object,
-  subsequent: PropTypes.object,
+  associatedMovement: PropTypes.object,
   selected: PropTypes.bool,
   onEdit: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
@@ -154,8 +118,6 @@ Movement.propTypes = {
     club: PropTypes.objectOf(PropTypes.bool),
     homeBase: PropTypes.objectOf(PropTypes.bool)
   }).isRequired,
-  oldestMovementDate: PropTypes.string.isRequired,
-  loadMovements: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/MovementList/MovementGroup.js
+++ b/src/components/MovementList/MovementGroup.js
@@ -30,34 +30,22 @@ class MovementGroup extends React.PureComponent {
       <GroupWrapper>
         <GroupLabel>{props.label}</GroupLabel>
         <ItemsContainer>
-          {filteredItems.map(item => {
-            const preceding = item.associations && item.associations.preceding
-              ? props.items.getByKey(item.associations.preceding)
-              : null;
-            const subsequent = item.associations && item.associations.subsequent
-              ? props.items.getByKey(item.associations.subsequent)
-              : null;
-
-            return (
-              <Movement
-                key={item.key}
-                data={item}
-                preceding={preceding}
-                subsequent={subsequent}
-                selected={item.key === props.selected}
-                onSelect={props.onSelect}
-                onEdit={props.onEdit}
-                timeWithDate={props.timeWithDate}
-                createMovementFromMovement={props.createMovementFromMovement}
-                onDelete={props.onDelete}
-                locked={isLocked(item, props.lockDate)}
-                aircraftSettings={props.aircraftSettings}
-                oldestMovementDate={props.oldestMovementDate}
-                loadMovements={props.loadMovements}
-                loading={props.loading}
-              />
-            );
-          })}
+          {filteredItems.map(item =>
+            <Movement
+              key={item.key}
+              data={item}
+              associatedMovement={props.associatedMovements[item.key]}
+              selected={item.key === props.selected}
+              onSelect={props.onSelect}
+              onEdit={props.onEdit}
+              timeWithDate={props.timeWithDate}
+              createMovementFromMovement={props.createMovementFromMovement}
+              onDelete={props.onDelete}
+              locked={isLocked(item, props.lockDate)}
+              aircraftSettings={props.aircraftSettings}
+              loading={props.loading}
+            />
+          )}
         </ItemsContainer>
       </GroupWrapper>
     );
@@ -67,6 +55,7 @@ class MovementGroup extends React.PureComponent {
 MovementGroup.propTypes = {
   label: PropTypes.string,
   items: PropTypes.object.isRequired,
+  associatedMovements: PropTypes.object.isRequired,
   selected: PropTypes.string,
   onSelect: PropTypes.func,
   predicate: PropTypes.func,
@@ -79,8 +68,6 @@ MovementGroup.propTypes = {
     club: PropTypes.objectOf(PropTypes.bool),
     homeBase: PropTypes.objectOf(PropTypes.bool)
   }).isRequired,
-  oldestMovementDate: PropTypes.string,
-  loadMovements: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired
 };
 

--- a/src/components/MovementList/MovementHeader.js
+++ b/src/components/MovementList/MovementHeader.js
@@ -21,67 +21,67 @@ const Wrapper = styled.div`
   ${props => !props.hasAssociatedMovement && `
     font-weight: bold;
   `}
-  
+
   .type {
     width: 50px;
   }
-  
+
   .immatriculation {
     width: 70px;
     padding-right: 10px;
   }
-  
+
   .homebase {
     flex: 0.5;
   }
-  
+
   .pilot, .datetime, .location {
     flex: 1;
     padding-right: 10px;
   }
-  
+
   .delete {
     width: 110px;
   }
-  
+
   .action {
     width: 200px;
   }
-  
+
   .pilot, .location {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  
+
   @media (max-width: 980px) {
     .action, .delete {
       width: 40px;
       text-align: center;
     }
   }
-  
+
   @media (max-width: 600px) {
     .location {
       display: none;
     }
   }
-  
+
   @media (max-width: 480px) {
     padding: 1em 0.5em;
-    
+
     .type {
       width: 40px;
     }
-    
+
     .immatriculation {
       flex: 1;
     }
-    
+
     .homebase {
       display: none;
     }
-    
+
     .action, .delete {
       width: 30px;
     }
@@ -136,7 +136,7 @@ class MovementHeader extends React.PureComponent {
         onClick={props.onClick}
         selected={props.selected}
         locked={props.locked}
-        hasAssociatedMovement={props.hasAssociatedMovement}
+        hasAssociatedMovement={!!props.associatedMovement}
       >
         <Column className="type">
           <MaterialIcon
@@ -156,14 +156,17 @@ class MovementHeader extends React.PureComponent {
         </Column>
         <Column className="location" alignMiddle>{getLocation(props.data)}</Column>
         <ActionColumn className="action" alignMiddle highlight>
-          {!props.hasAssociatedMovement && (
+          {props.associatedMovement === null ? (
             <Action
               label={ACTION_LABELS[props.data.type].label}
               icon={ACTION_LABELS[props.data.type].icon}
               onClick={this.handleActionClick}
               responsive
             />
-          )}
+          ) : props.associatedMovement === undefined
+            ? <MaterialIcon icon="sync" rotate="left"/>
+            : null
+          }
         </ActionColumn>
         <ActionColumn className="delete" alignMiddle>
           {!props.locked && (
@@ -195,7 +198,7 @@ MovementHeader.propTypes = {
   onDelete: PropTypes.func.isRequired,
   locked: PropTypes.bool,
   onClick: PropTypes.func,
-  hasAssociatedMovement: PropTypes.bool.isRequired,
+  associatedMovement: PropTypes.object,
   isHomeBase: PropTypes.bool.isRequired
 };
 

--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -36,12 +36,6 @@ class MovementList extends React.PureComponent {
     this.props.loadItems(true);
   }
 
-  getDateString(movement) {
-    const date = dates.formatDate(movement.date);
-    const time = dates.formatTime(movement.date, movement.time);
-    return `${date} ${time}`;
-  }
-
   render() {
     if (this.props.lockDate.loading === true
       || !this.props.aircraftSettings.club
@@ -56,15 +50,12 @@ class MovementList extends React.PureComponent {
         hide={this.props.hideDeleteConfirmationDialog}
       />) : null;
 
-    const oldestMovementDate = this.props.items.array.length > 0
-      ? this.getDateString(this.props.items.array[this.props.items.array.length - 1])
-      : null;
-
     return (
       <div>
         <MovementGroup
           label="Ab morgen"
           items={this.props.items}
+          associatedMovements={this.props.associatedMovements}
           selected={this.props.selected}
           onSelect={this.props.onSelect}
           predicate={afterTodayPredicate}
@@ -74,13 +65,12 @@ class MovementList extends React.PureComponent {
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
-          oldestMovementDate={oldestMovementDate}
-          loadMovements={this.props.loadItems}
           loading={this.props.loading}
         />
         <MovementGroup
           label="Heute"
           items={this.props.items}
+          associatedMovements={this.props.associatedMovements}
           selected={this.props.selected}
           onSelect={this.props.onSelect}
           predicate={todayPredicate}
@@ -90,13 +80,12 @@ class MovementList extends React.PureComponent {
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
-          oldestMovementDate={oldestMovementDate}
-          loadMovements={this.props.loadItems}
           loading={this.props.loading}
         />
         <MovementGroup
           label="Gestern"
           items={this.props.items}
+          associatedMovements={this.props.associatedMovements}
           selected={this.props.selected}
           onSelect={this.props.onSelect}
           predicate={yesterdayPredicate}
@@ -106,13 +95,12 @@ class MovementList extends React.PureComponent {
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
-          oldestMovementDate={oldestMovementDate}
-          loadMovements={this.props.loadItems}
           loading={this.props.loading}
         />
         <MovementGroup
           label="Dieser Monat"
           items={this.props.items}
+          associatedMovements={this.props.associatedMovements}
           selected={this.props.selected}
           onSelect={this.props.onSelect}
           predicate={thisMonthPredicate}
@@ -121,13 +109,12 @@ class MovementList extends React.PureComponent {
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
-          oldestMovementDate={oldestMovementDate}
-          loadMovements={this.props.loadItems}
           loading={this.props.loading}
         />
         <MovementGroup
           label="Älter"
           items={this.props.items}
+          associatedMovements={this.props.associatedMovements}
           selected={this.props.selected}
           onSelect={this.props.onSelect}
           predicate={olderPredicate}
@@ -136,8 +123,6 @@ class MovementList extends React.PureComponent {
           onDelete={this.props.showDeleteConfirmationDialog}
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
-          oldestMovementDate={oldestMovementDate}
-          loadMovements={this.props.loadItems}
           loading={this.props.loading}
         />
         {this.props.loading && <LoadingInfo/>}
@@ -152,6 +137,7 @@ MovementList.propTypes = {
   loadItems: PropTypes.func.isRequired,
   loadAircraftSettings: PropTypes.func.isRequired,
   items: PropTypes.object.isRequired,
+  associatedMovements: PropTypes.object.isRequired,
   selected: PropTypes.string,
   onSelect: PropTypes.func,
   loading: PropTypes.bool.isRequired,

--- a/src/containers/MovementListContainer.js
+++ b/src/containers/MovementListContainer.js
@@ -14,6 +14,7 @@ import MovementList from '../components/MovementList';
 const mapStateToProps = state => {
   return {
     items: state.movements.data,
+    associatedMovements: state.movements.associatedMovements,
     loading: state.movements.loading,
     loadingFailed: state.movements.loadingFailed,
     lockDate: state.settings.lockDate,

--- a/src/modules/movements/actions.js
+++ b/src/modules/movements/actions.js
@@ -1,11 +1,16 @@
 export const LOAD_MOVEMENTS = 'LOAD_MOVEMENTS';
 export const SET_MOVEMENTS_LOADING = 'SET_MOVEMENTS_LOADING';
 export const LOAD_MOVEMENTS_FAILURE = 'LOAD_MOVEMENTS_FAILURE';
-export const MOVEMENTS_ADDED = 'MOVEMENTS_ADDED';
+export const SET_MOVEMENTS = 'SET_MOVEMENTS';
 export const MOVEMENT_ADDED = 'MOVEMENT_ADDED';
 export const MOVEMENT_CHANGED = 'MOVEMENT_CHANGED';
 export const MOVEMENT_DELETED = 'MOVEMENT_DELETED';
+export const IMMATRICULATION_MOVEMENT_ADDED = 'IMMATRICULATION_MOVEMENT_ADDED';
+export const IMMATRICULATION_MOVEMENT_CHANGED = 'IMMATRICULATION_MOVEMENT_CHANGED';
+export const IMMATRICULATION_MOVEMENT_DELETED = 'IMMATRICULATION_MOVEMENT_DELETED';
 export const DELETE_MOVEMENT = 'DELETE_MOVEMENT';
+export const SET_ASSOCIATED_MOVEMENTS = 'SET_ASSOCIATED_MOVEMENTS';
+export const SET_MOVEMENTS_BY_IMMATRICULATION = 'SET_MOVEMENTS_BY_IMMATRICULATION';
 export const INIT_NEW_MOVEMENT = 'INIT_NEW_MOVEMENT';
 export const INIT_NEW_MOVEMENT_FROM_MOVEMENT = 'INIT_NEW_MOVEMENT_FROM_MOVEMENT';
 export const SAVE_MOVEMENT = 'SAVE_MOVEMENT';
@@ -36,13 +41,11 @@ export function loadMovementsFailure() {
   };
 }
 
-export function movementsAdded(snapshot, movementType, clear) {
+export function setMovements(movements) {
   return {
-    type: MOVEMENTS_ADDED,
+    type: SET_MOVEMENTS,
     payload: {
-      snapshot,
-      movementType,
-      clear
+      movements
     },
   };
 }
@@ -77,6 +80,36 @@ export function movementDeleted(snapshot, movementType) {
   };
 }
 
+export function immatriculationMovementAdded(snapshot, movementType) {
+  return {
+    type: IMMATRICULATION_MOVEMENT_ADDED,
+    payload: {
+      snapshot,
+      movementType
+    },
+  };
+}
+
+export function immatriculationMovementChanged(snapshot, movementType) {
+  return {
+    type: IMMATRICULATION_MOVEMENT_CHANGED,
+    payload: {
+      snapshot,
+      movementType
+    },
+  };
+}
+
+export function immatriculationMovementDeleted(snapshot, movementType) {
+  return {
+    type: IMMATRICULATION_MOVEMENT_DELETED,
+    payload: {
+      snapshot,
+      movementType
+    },
+  };
+}
+
 export function deleteMovement(movementType, key, successAction) {
   return {
     type: DELETE_MOVEMENT,
@@ -86,6 +119,25 @@ export function deleteMovement(movementType, key, successAction) {
       successAction,
     },
   };
+}
+
+export function setAssociatiatedMovements(associatedMovements) {
+  return {
+    type: SET_ASSOCIATED_MOVEMENTS,
+    payload: {
+      associatedMovements
+    }
+  }
+}
+
+export function setMovementsByImmatriculation(immatriculation, movements) {
+  return {
+    type: SET_MOVEMENTS_BY_IMMATRICULATION,
+    payload: {
+      immatriculation,
+      movements
+    }
+  }
 }
 
 export function initNewMovement(movementType) {

--- a/src/modules/movements/associate.spec.js
+++ b/src/modules/movements/associate.spec.js
@@ -1,174 +1,168 @@
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
-import {compareDescending} from '../../util/movements';
-import associate from './associate';
+import getAssociations from './associate';
 
 describe('modules', () => {
   describe('movements', () => {
     describe('associate', () => {
+      const homeBaseAicrafts = new Set(['HBABC', 'HBERT']);
+
       it('should return same movements object if no movements', () => {
+        const homeBaseAicrafts = new Set();
         const movements = new ImmutableItemsArray([]);
-        const associated = associate(movements, compareDescending);
-        expect(associated).toBe(movements);
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+        expect(associations).toEqual({});
       });
 
-      it('should set empty associations for single movement', () => {
-        const associated = associate(new ImmutableItemsArray([{
-          key: 'dep1',
-          immatriculation: 'HBABC'
-        }]), compareDescending);
-
-        expect(associated.array).toEqual([{
+      it('should return undefined for single movement', () => {
+        const movements = new ImmutableItemsArray([{
           key: 'dep1',
           immatriculation: 'HBABC',
-          associations: {
-            preceding: null,
-            subsequent: null
-          }
+          type: 'departure'
         }]);
+
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+
+        expect(associations).toEqual({
+          dep1: undefined
+        });
       });
 
       it('should associate two movements of certain aircraft', () => {
-        const associated = associate(new ImmutableItemsArray([{
-          key: 'arr1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '14:00'
-        }, {
-          key: 'dep1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '13:30'
-        }]), compareDescending);
-
-        expect(associated.array).toEqual([{
+        const movements = new ImmutableItemsArray([{
           key: 'arr1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '14:00',
-          associations: {
-            preceding: 'dep1',
-            subsequent: null
-          }
+          type: 'arrival'
         }, {
           key: 'dep1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '13:30',
-          associations: {
-            preceding: null,
-            subsequent: 'arr1'
-          }
+          type: 'departure'
         }]);
+
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+
+        expect(associations).toEqual({
+          arr1: {
+            key: 'dep1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '13:30',
+            type: 'departure'
+          },
+          dep1: {
+            key: 'arr1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '14:00',
+            type: 'arrival'
+          }
+        });
       });
 
       it('should associate movements of multiple aircrafts (grouped by aircraft)', () => {
-        const associated = associate(new ImmutableItemsArray([{
-          key: 'arr1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '15:30'
-        }, {
-          key: 'arr2',
-          immatriculation: 'HBERT',
-          date: '2017-05-21',
-          time: '15:00'
-        }, {
-          key: 'dep1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '11:30'
-        }, {
-          key: 'dep2',
-          immatriculation: 'HBERT',
-          date: '2017-05-21',
-          time: '10:30'
-        }]), compareDescending);
-
-        expect(associated.array).toEqual([{
+        const movements = new ImmutableItemsArray([{
           key: 'arr1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '15:30',
-          associations: {
-            preceding: 'dep1',
-            subsequent: null
-          }
+          type: 'arrival'
         }, {
           key: 'arr2',
           immatriculation: 'HBERT',
           date: '2017-05-21',
           time: '15:00',
-          associations: {
-            preceding: 'dep2',
-            subsequent: null
-          }
+          type: 'arrival'
         }, {
           key: 'dep1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '11:30',
-          associations: {
-            preceding: null,
-            subsequent: 'arr1'
-          }
+          type: 'departure'
         }, {
           key: 'dep2',
           immatriculation: 'HBERT',
           date: '2017-05-21',
           time: '10:30',
-          associations: {
-            preceding: null,
-            subsequent: 'arr2'
-          }
+          type: 'departure'
         }]);
+
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+
+        expect(associations).toEqual({
+          arr1: {
+            key: 'dep1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '11:30',
+            type: 'departure'
+          },
+          arr2: {
+            key: 'dep2',
+            immatriculation: 'HBERT',
+            date: '2017-05-21',
+            time: '10:30',
+            type: 'departure'
+          },
+          dep1: {
+            key: 'arr1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '15:30',
+            type: 'arrival'
+          },
+          dep2: {
+            key: 'arr2',
+            immatriculation: 'HBERT',
+            date: '2017-05-21',
+            time: '15:00',
+            type: 'arrival'
+          }
+        });
       });
 
       it('should associate three movements of certain aircraft', () => {
-        const associated = associate(new ImmutableItemsArray([{
-          key: 'dep2',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '13:30'
-        }, {
-          key: 'arr1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '12:00'
-        }, {
-          key: 'dep1',
-          immatriculation: 'HBABC',
-          date: '2017-05-21',
-          time: '11:00'
-        }]), compareDescending);
-
-        expect(associated.array).toEqual([{
+        const movements = new ImmutableItemsArray([{
           key: 'dep2',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '13:30',
-          associations: {
-            preceding: 'arr1',
-            subsequent: null
-          }
+          type: 'departure'
         }, {
           key: 'arr1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '12:00',
-          associations: {
-            preceding: 'dep1',
-            subsequent: 'dep2'
-          }
+          type: 'arrival'
         }, {
           key: 'dep1',
           immatriculation: 'HBABC',
           date: '2017-05-21',
           time: '11:00',
-          associations: {
-            preceding: null,
-            subsequent: 'arr1'
-          }
+          type: 'departure'
         }]);
+
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+
+        expect(associations).toEqual({
+          dep2: undefined,
+          arr1: {
+            key: 'dep1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '11:00',
+            type: 'departure'
+          },
+          dep1: {
+            key: 'arr1',
+            immatriculation: 'HBABC',
+            date: '2017-05-21',
+            time: '12:00',
+            type: 'arrival'
+          }
+        });
       });
     });
   });

--- a/src/modules/movements/reducer.spec.js
+++ b/src/modules/movements/reducer.spec.js
@@ -1,310 +1,61 @@
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
 import * as actions from './actions';
 import * as reducer from './reducer';
-import FakeFirebaseSnapshot from '../../../test/FakeFirebaseSnapshot'
 
 describe('modules', () => {
   describe('movements', () => {
     describe('reducers', () => {
-      describe('childrenAdded', () => {
-        it('should add children', () => {
+      describe('setMovements', () => {
+        it('should set movements', () => {
           const state = {
             loading: true,
-            data: new ImmutableItemsArray([{
-              key: 'dep2',
-              type: 'departure',
-              immatriculation: 'HBKOF',
-              date: '2017-04-28',
-              time: '15:00'
-            }, {
-              key: 'dep1',
-              type: 'departure',
-              immatriculation: 'HBKFW',
-              date: '2017-04-28',
-              time: '14:00'
-            }])
-          };
-
-          const snapshot = new FakeFirebaseSnapshot(null, [
-            new FakeFirebaseSnapshot('arr1', {
-              immatriculation: 'HBKOF',
-              dateTime: '2017-04-28T14:00:00.000Z'
-            }),
-            new FakeFirebaseSnapshot('arr2', {
-              immatriculation: 'HBKFW',
-              dateTime: '2017-04-28T15:00:00.000Z'
-            })
-          ]);
-          const action = actions.movementsAdded(snapshot, 'arrival');
-
-          const newState = reducer.childrenAdded(state, action);
-
-          expect(newState.loading).toEqual(false);
-
-          // `key` must have been added
-          // `type: 'departure'` must have been added
-          // `dateTime` must have been converted to `date` and `time` in local time
-          // items must have been inserted in the right order
-          // associations must have been added
-          expect(newState.data.array).toEqual([{
-            key: 'arr2',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            time: '17:00',
-            type: 'arrival',
-            associations: {
-              preceding: 'dep1',
-              subsequent: null
-            }
-          }, {
-            key: 'arr1',
-            date: '2017-04-28',
-            immatriculation: 'HBKOF',
-            time: '16:00',
-            type: 'arrival',
-            associations: {
-              preceding: 'dep2',
-              subsequent: null
-            }
-          }, {
-            key: 'dep2',
-            date: '2017-04-28',
-            immatriculation: 'HBKOF',
-            time: '15:00',
-            type: 'departure',
-            associations: {
-              preceding: null,
-              subsequent: 'arr1'
-            }
-          }, {
-            key: 'dep1',
-            time: '14:00',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            type: 'departure',
-            associations: {
-              preceding: null,
-              subsequent: 'arr2'
-            }
-          }]);
-        });
-
-        it('should clear existing children if flag set', () => {
-          const state = {
-            loading: true,
-            data: new ImmutableItemsArray([{
-              key: 'dep2',
-              type: 'departure',
-              immatriculation: 'HBKOF',
-              date: '2017-04-28',
-              time: '15:00'
-            }, {
-              key: 'dep1',
-              type: 'departure',
-              immatriculation: 'HBKFW',
-              date: '2017-04-28',
-              time: '14:00'
-            }])
-          };
-
-          const snapshot = new FakeFirebaseSnapshot(null, [
-            new FakeFirebaseSnapshot('arr1', {
-              immatriculation: 'HBKOF',
-              dateTime: '2017-04-28T14:00:00.000Z'
-            }),
-            new FakeFirebaseSnapshot('arr2', {
-              immatriculation: 'HBKFW',
-              dateTime: '2017-04-28T15:00:00.000Z'
-            })
-          ]);
-          const action = actions.movementsAdded(snapshot, 'arrival', true);
-
-          const newState = reducer.childrenAdded(state, action);
-
-          expect(newState.loading).toEqual(false);
-
-          // `key` must have been added
-          // `type: 'departure'` must have been added
-          // `dateTime` must have been converted to `date` and `time` in local time
-          // existing items must have been removed
-          // items must have been inserted in the right order
-          // associations must have been added
-          expect(newState.data.array).toEqual([{
-            key: 'arr2',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            time: '17:00',
-            type: 'arrival',
-            associations: {
-              preceding: null,
-              subsequent: null
-            }
-          }, {
-            key: 'arr1',
-            date: '2017-04-28',
-            immatriculation: 'HBKOF',
-            time: '16:00',
-            type: 'arrival',
-            associations: {
-              preceding: null,
-              subsequent: null
-            }
-          }]);
-        });
-      });
-
-      describe('childAdded', () => {
-        it('should add child', () => {
-          const state = {
-            data: new ImmutableItemsArray([{
-              key: 'dep2',
-              type: 'departure',
-              immatriculation: 'HBKOF',
-              date: '2017-04-28',
-              time: '15:00'
-            }, {
-              key: 'dep1',
-              type: 'departure',
-              immatriculation: 'HBKFW',
-              date: '2017-04-28',
-              time: '14:00'
-            }])
-          };
-
-          const snapshot = new FakeFirebaseSnapshot('arr1', {
-            immatriculation: 'HBKFW',
-            dateTime: '2017-04-28T12:30:00.000Z'
-          });
-          const action = actions.movementAdded(snapshot, 'arrival');
-
-          const newState = reducer.childAdded(state, action);
-
-          // `key` must have been added
-          // `type: 'departure'` must have been added
-          // `dateTime` must have been converted to `date` and `time` in local time
-          // item must have been inserted in the right order
-          // associations must have been added
-          expect(newState.data.array).toEqual([{
-            key: 'dep2',
-            date: '2017-04-28',
-            immatriculation: 'HBKOF',
-            time: '15:00',
-            type: 'departure',
-            associations: {
-              preceding: null,
-              subsequent: null
-            }
-          }, {
-            key: 'arr1',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            time: '14:30',
-            type: 'arrival',
-            associations: {
-              preceding: 'dep1',
-              subsequent: null
-            }
-          }, {
-            key: 'dep1',
-            time: '14:00',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            type: 'departure',
-            associations: {
-              preceding: null,
-              subsequent: 'arr1'
-            }
-          }]);
-        });
-      });
-
-      describe('childChanged', () => {
-        it('should change child', () => {
-          const state = {
             data: new ImmutableItemsArray([{
               key: 'arr1',
               type: 'arrival',
-              immatriculation: 'HBKFW',
-              date: '2017-04-28',
-              time: '15:00'
-            }, {
-              key: 'dep1',
-              type: 'departure',
-              immatriculation: 'HBKFW',
-              date: '2017-04-28',
-              time: '14:00'
-            }])
-          };
-
-          const snapshot = new FakeFirebaseSnapshot('dep1', {
-            immatriculation: 'HBKFW',
-            dateTime: '2017-04-28T13:30:00.000Z'
-          });
-          const action = actions.movementChanged(snapshot, 'departure');
-
-          const newState = reducer.childChanged(state, action);
-
-          // item must have been updated
-          // item must have put to the right place (ordered chronologically)
-          // associations must have been added
-          expect(newState.data.array).toEqual([{
-            key: 'dep1',
-            time: '15:30',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            type: 'departure',
-            associations: {
-              preceding: 'arr1',
-              subsequent: null
-            }
-          }, {
-            key: 'arr1',
-            date: '2017-04-28',
-            immatriculation: 'HBKFW',
-            time: '15:00',
-            type: 'arrival',
-            associations: {
-              preceding: null,
-              subsequent: 'dep1'
-            }
-          }]);
-        });
-      });
-
-      describe('childRemoved', () => {
-        it('should remove child', () => {
-          const state = {
-            data: new ImmutableItemsArray([{
-              key: 'dep2',
-              type: 'departure',
               immatriculation: 'HBKOF',
               date: '2017-04-28',
               time: '15:00'
             }, {
               key: 'dep1',
               type: 'departure',
-              immatriculation: 'HBKFW',
+              immatriculation: 'HBKOF',
               date: '2017-04-28',
               time: '14:00'
             }])
           };
 
-          const snapshot = new FakeFirebaseSnapshot('dep1');
-          const action = actions.movementDeleted(snapshot, 'departure');
-
-          const newState = reducer.childRemoved(state, action);
-
-          expect(newState.data.array).toEqual([{
-            key: 'dep2',
-            date: '2017-04-28',
-            immatriculation: 'HBKOF',
-            time: '15:00',
+          const newMovements = new ImmutableItemsArray([{
+            key: 'arr2',
+            type: 'arrival',
+            immatriculation: 'HBKFW',
+            date: '2017-04-29',
+            time: '15:00'
+          }, {
+            key: 'dep1',
             type: 'departure',
-            associations: {
-              preceding: null,
-              subsequent: null
-            }
+            immatriculation: 'HBKFW',
+            date: '2017-04-29',
+            time: '14:00'
+          }, {
+            key: 'arr1',
+            type: 'arrival',
+            immatriculation: 'HBKOF',
+            date: '2017-04-28',
+            time: '15:00'
+          }, {
+            key: 'dep1',
+            type: 'departure',
+            immatriculation: 'HBKOF',
+            date: '2017-04-28',
+            time: '14:00'
           }]);
+
+          const action = actions.setMovements(newMovements);
+
+          const newState = reducer.setMovements(state, action);
+
+          expect(newState.loading).toEqual(false);
+          expect(newState.data).toEqual(newMovements);
         });
       });
     });

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -1,15 +1,19 @@
 import { getPagination } from './pagination';
 import { takeEvery, takeLatest } from 'redux-saga'
-import { put, call, select, fork } from 'redux-saga/effects'
+import { put, call, select, fork, all } from 'redux-saga/effects'
 import { initialize, destroy, getFormValues } from 'redux-form'
 import createChannel, { monitor } from '../../util/createChannel';
 import * as actions from './actions';
 import * as remote from './remote';
-import { localToFirebase, firebaseToLocal, transferValues } from '../../util/movements';
+import {localToFirebase, firebaseToLocal, transferValues, compareDescending} from '../../util/movements';
 import { error } from '../../util/log';
 import dates from '../../util/dates';
+import ImmutableItemsArray from '../../util/ImmutableItemsArray';
+import getAssociations, {getAssociatedMovement} from './associate';
+import firebase from '../../util/firebase';
 
-export const stateSelector = (state, key) => state.movements;
+export const stateSelector = state => state.movements;
+export const settingsSelector = state => state.settings;
 
 export const movementSelector = (state, key) => state.movements.data.getByKey(key);
 
@@ -132,11 +136,18 @@ export function* loadMovements(channel, action) {
         arrivalsEnd
       );
 
-      yield call(monitorRef, departures.ref, channel, 'departure');
-      yield call(monitorRef, arrivals.ref, channel, 'arrival');
+      const eventActions = {
+        added: actions.movementAdded,
+        changed: actions.movementChanged,
+        removed: actions.movementDeleted
+      };
 
-      channel.put(actions.movementsAdded(departures.snapshot, 'departure', clear));
-      channel.put(actions.movementsAdded(arrivals.snapshot, 'arrival', clear));
+      yield call(monitorRef, departures.ref, channel, 'departure', eventActions);
+      yield call(monitorRef, arrivals.ref, channel, 'arrival', eventActions);
+
+      const existingMovements = clear ? new ImmutableItemsArray() : movements.data;
+
+      yield call(addMovements, departures.snapshot, arrivals.snapshot, existingMovements, channel);
     }
   } catch(e) {
     error('Failed to load movements', e);
@@ -144,14 +155,106 @@ export function* loadMovements(channel, action) {
   }
 }
 
-export function* monitorRef(ref, channel, movementType) {
+export function* getHomeBaseAircrafts() {
+  const {aircrafts: aircraftSettings} = yield select(settingsSelector);
+
+  const homeBaseAircrafts = new Set();
+  addAircraft(aircraftSettings.club, homeBaseAircrafts);
+  addAircraft(aircraftSettings.homeBase, homeBaseAircrafts);
+
+  return homeBaseAircrafts;
+}
+
+export function* addMovements(departuresSnapshot, arrivalsSnapshot, existingMovements, channel) {
+  const movements = [];
+
+  departuresSnapshot.forEach(transformToLocal(movements, 'departure'));
+  arrivalsSnapshot.forEach(transformToLocal(movements, 'arrival'));
+
+  const newData = existingMovements.insertAll(movements, compareDescending);
+
+  channel.put(actions.setMovements(newData));
+}
+
+export function* associateMovements(channel) {
+  const homeBaseAircrafts = yield call(getHomeBaseAircrafts);
+  const {data} = yield select(stateSelector);
+
+  const associations = getAssociations(data.array, homeBaseAircrafts);
+  channel.put(actions.setAssociatiatedMovements(associations));
+
+  const associationsToLoad = data.array.filter(item => associations[item.key] === undefined);
+  yield call(loadAssociatedMovements, associationsToLoad, homeBaseAircrafts, channel);
+}
+
+export function* loadAssociatedMovements(movements, homeBaseAircrafts, channel) {
+  const callEvents = movements.map(movement => call(loadAssociatedMovement, movement, homeBaseAircrafts, channel));
+  const results = yield all(callEvents);
+  const associatedMovements = results.reduce((acc, result) => ({
+    ...acc,
+    [result.movement.key]: result.associatedMovement
+  }), {});
+  channel.put(actions.setAssociatiatedMovements(associatedMovements));
+}
+
+export function* loadAssociatedMovement(movement, homeBaseAircrafts, channel) {
+  const relevantMovements = yield call(getMovementsByImmatriculation, movement.immatriculation, channel);
+
+  const isHomeBase = homeBaseAircrafts.has(movement.immatriculation);
+
+  const index = relevantMovements.array.findIndex(m => m.key === movement.key);
+
+  const preceding = relevantMovements.array[index + 1];
+  const subsequent = relevantMovements.array[index - 1];
+
+  const associatedMovement = getAssociatedMovement(movement.type, isHomeBase, preceding, subsequent) || null;
+
+  return {
+    movement,
+    associatedMovement
+  };
+}
+
+export function* getMovementsByImmatriculation(immatriculation, channel) {
+  const {byImmatriculation} = yield select(stateSelector);
+
+  if (byImmatriculation[immatriculation]) {
+    return byImmatriculation[immatriculation];
+  }
+
+  const departures = yield call(loadByImmatriculation, '/departures', immatriculation);
+  const arrivals = yield call(loadByImmatriculation, '/arrivals', immatriculation);
+
+  // monitor all loaded movements to remove associated movements which aren't present
+  // in the loaded movement list but are older
+  const eventActions = {
+    added: actions.immatriculationMovementAdded,
+    changed: actions.immatriculationMovementChanged,
+    removed: actions.immatriculationMovementDeleted
+  }
+  yield call(monitorRef, departures.ref, channel, 'departure', eventActions);
+  yield call(monitorRef, arrivals.ref, channel, 'arrival', eventActions);
+
+  const movements = [];
+
+  departures.snapshot.forEach(transformToLocal(movements, 'departure'));
+  arrivals.snapshot.forEach(transformToLocal(movements, 'arrival'));
+
+  const arr = new ImmutableItemsArray().insertAll(movements, compareDescending);
+
+  channel.put(actions.setMovementsByImmatriculation(immatriculation, arr));
+
+  return arr;
+}
+
+export function* monitorRef(ref, channel, movementType, eventActions) {
   ref.off('child_added');
   ref.off('child_changed');
   ref.off('child_removed');
 
-  const childAdded = createDelegate(channel, actions.movementAdded, movementType);
-  const childChanged = createDelegate(channel, actions.movementChanged, movementType);
-  const childRemoved = createDelegate(channel, actions.movementDeleted, movementType);
+  const childAdded = createDelegate(channel, eventActions.added, movementType);
+  const childChanged = createDelegate(channel, eventActions.changed, movementType);
+  const childRemoved = createDelegate(channel, eventActions.removed, movementType);
 
   ref.on('child_added', childAdded);
   ref.on('child_changed', childChanged);
@@ -160,6 +263,127 @@ export function* monitorRef(ref, channel, movementType) {
 
 export function createDelegate(channel, action, movementType) {
   return snapshot => channel.put(action(snapshot, movementType))
+}
+
+export function* movementAdded(channel, action) {
+  const {snapshot, movementType} = action.payload;
+  const state = yield select(stateSelector);
+  yield call(addMovementToState, snapshot, movementType, state, channel);
+}
+
+export function* movementChanged(channel, action) {
+  const {snapshot, movementType} = action.payload;
+  const currentState = yield call(removeMovementFromState, snapshot, channel);
+  yield call(addMovementToState, snapshot, movementType, currentState, channel);
+}
+
+export function* movementDeleted(channel, action) {
+  const {snapshot} = action.payload;
+  yield call(removeMovementFromState, snapshot, channel);
+}
+
+export function* addMovementToState(snapshot, movementType, currentState, channel) {
+  const {data, byImmatriculation} = currentState;
+
+  if (!data.getByKey(snapshot.key)) {
+    const movement = transformSnapshotToLocal(snapshot, movementType);
+
+    const newData = data.insert(movement, compareDescending);
+
+    // if is last element, it was added to the range only because a movement
+    // in the range was deleted. to prevent the `movementAdded` callback
+    // from messing up the state, because it's executed parallel to the
+    // `movementDeleted` callback, we ignore it here.
+    if (newData.array[newData.array.length - 1].key === movement.key) {
+      return;
+    }
+
+    if (byImmatriculation[movement.immatriculation]) {
+      const newByImmatriculation = byImmatriculation[movement.immatriculation].insert(movement, compareDescending);
+      channel.put(actions.setMovementsByImmatriculation(movement.immatriculation, newByImmatriculation));
+    }
+
+    channel.put(actions.setMovements(newData));
+  }
+}
+
+export function* removeMovementFromState(snapshot, channel) {
+  const {data, byImmatriculation} = yield select(stateSelector);
+
+  const newState = {
+    byImmatriculation
+  };
+
+  const immatriculation = snapshot.val().immatriculation;
+
+  if (byImmatriculation[immatriculation]) {
+    newState.byImmatriculation[immatriculation] = byImmatriculation[immatriculation].remove(snapshot.key)
+    channel.put(
+      actions.setMovementsByImmatriculation(
+        immatriculation,
+        newState.byImmatriculation[immatriculation]
+      )
+    );
+  }
+
+  newState.data = data.remove(snapshot.key);
+  channel.put(actions.setMovements(newState.data));
+
+  return newState;
+}
+
+export function* immatriculationMovementAdded(channel, action) {
+  const {snapshot, movementType} = action.payload;
+  const state = yield select(stateSelector);
+  if (!state.data.getByKey(snapshot.key)) { // if movement is in loaded range, it get's handled by the movementAdded action
+    yield call(addImmatriculationMovementToState, snapshot, movementType, state, channel);
+  }
+}
+
+export function* immatriculationMovementChanged(channel, action) {
+  const {snapshot, movementType} = action.payload;
+  const state = yield select(stateSelector);
+  if (!state.data.getByKey(snapshot.key)) { // if movement is in loaded range, it get's handled by the movementChanged action
+    const currentState = yield call(removeImmatriculationMovementFromState, snapshot, channel);
+    yield call(addImmatriculationMovementToState, snapshot, movementType, currentState, channel);
+  }
+}
+
+export function* immatriculationMovementDeleted(channel, action) {
+  const {snapshot} = action.payload;
+  const state = yield select(stateSelector);
+  if (!state.data.getByKey(snapshot.key)) { // if movement is in loaded range, it get's handled by the movementDeleted action
+    yield call(removeImmatriculationMovementFromState, snapshot, channel);
+  }
+}
+
+export function* addImmatriculationMovementToState(snapshot, movementType, currentState, channel) {
+  const {data, byImmatriculation} = currentState;
+
+  if (!byImmatriculation[snapshot.val().immatriculation].getByKey(snapshot.key)) {
+    const movement = transformSnapshotToLocal(snapshot, movementType);
+
+    const newByImmatriculation = byImmatriculation[movement.immatriculation].insert(movement, compareDescending);
+    channel.put(actions.setMovementsByImmatriculation(movement.immatriculation, newByImmatriculation));
+
+    channel.put(actions.setMovements(data)); // put SET_MOVEMENTS action with same data just to trigger `associateMovements`
+  }
+}
+
+export function* removeImmatriculationMovementFromState(snapshot, channel) {
+  const {data, byImmatriculation} = yield select(stateSelector);
+
+  const immatriculation = snapshot.val().immatriculation;
+
+  const newByImmatriculation = byImmatriculation[immatriculation].remove(snapshot.key);
+  channel.put(
+    actions.setMovementsByImmatriculation(
+      immatriculation,
+      newByImmatriculation
+    )
+  );
+
+  channel.put(actions.setMovements(data)); // put SET_MOVEMENTS action with same data just to trigger `associateMovements`
 }
 
 export function* deleteMovement(action) {
@@ -244,12 +468,54 @@ function getPathByMovementType(type) {
   }
 }
 
+
+const transformSnapshotToLocal = (snapshot, movementType) => {
+  const movement = firebaseToLocal(snapshot.val());
+  movement.key = snapshot.key;
+  movement.type = movementType;
+  return movement;
+}
+
+const transformToLocal = (movements, movementType) => item => {
+  const movement = transformSnapshotToLocal(item, movementType);
+  movements.push(movement);
+}
+
+const addAircraft = (map, set) => {
+  Object.keys(map).forEach(aircraft => {
+    if (map[aircraft] === true) {
+      set.add(aircraft);
+    }
+  });
+}
+
+export function loadByImmatriculation(path, immatriculation) {
+  return new Promise(resolve => {
+    const ref = firebase(path)
+      .orderByChild('immatriculation')
+      .equalTo(immatriculation);
+    ref.once('value', snapshot => {
+      resolve({
+        snapshot,
+        ref
+      });
+    });
+  });
+}
+
 export default function* sagas() {
   const channel = createChannel();
 
   yield [
     fork(monitor, channel),
     fork(takeEvery, actions.LOAD_MOVEMENTS, loadMovements, channel),
+    fork(takeEvery, actions.SET_MOVEMENTS, associateMovements, channel),
+    fork(takeEvery, actions.MOVEMENT_ADDED, movementAdded, channel),
+    fork(takeEvery, actions.MOVEMENT_CHANGED, movementChanged, channel),
+    fork(takeEvery, actions.MOVEMENT_DELETED, movementDeleted, channel),
+    fork(takeEvery, actions.IMMATRICULATION_MOVEMENT_ADDED, immatriculationMovementAdded, channel),
+    fork(takeEvery, actions.IMMATRICULATION_MOVEMENT_CHANGED, immatriculationMovementChanged, channel),
+    fork(takeEvery, actions.IMMATRICULATION_MOVEMENT_DELETED, immatriculationMovementDeleted, channel),
     fork(takeEvery, actions.DELETE_MOVEMENT, deleteMovement),
     fork(takeEvery, actions.INIT_NEW_MOVEMENT, initNewMovement),
     fork(takeEvery, actions.INIT_NEW_MOVEMENT_FROM_MOVEMENT, initNewMovementFromMovement),


### PR DESCRIPTION
Before, the associated movement was searched only in the loaded
set of movements. Now, we look at all the movements and are able
to match them also if the associated movement is older and not
loaded yet.