### PR TITLE
Take custom aircrafts from settings into account during import

### DIFF
--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -182,6 +182,10 @@
           ".read": "auth !== null",
           ".write":  "auth !== null && root.child('admins/' + auth.uid).exists()"
         },
+        "custom": {
+          ".read": "auth !== null && root.child('admins/' + auth.uid).exists()",
+          ".write": false
+        },
         "$other": {
           ".validate": false
         }

--- a/src/util/importAircrafts.js
+++ b/src/util/importAircrafts.js
@@ -3,6 +3,7 @@ import importCsv from './importCsv.js';
 function importAircrafts(csvString) {
   const options = {
     path: '/aircrafts',
+    additionalEntriesPath: '/settings/aircrafts/custom',
     columns: [
       { csv: 'Registration', isKey: true, isFirebaseKey: true },
       { csv: 'Type', firebase: 'type' },


### PR DESCRIPTION
You can specify some custom aircrafts under /settings/aircrafts/custom
that should be part of the aircrafts list even if they're not part of
the CSV that is imported. E.g. that's useful if there are some aircrafts
home based on your airport that are registered abroad (e.g. aircrafts
with "N...." registration on an airport in Switzerland, where we usually
import only the aircrafts from the BAZL register ("HB...").