### PR TITLE
Remove annoying automatic scrolling in dropdown component

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -45,14 +45,6 @@ class Dropdown extends Component {
     });
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.focusedOption !== prevState.focusedOption) {
-      scrollIntoView(this.options[this.state.focusedOption], {
-        validTarget: target => target.classList && target.classList.contains('flightbox-dropdown-options-container')
-      });
-    }
-  }
-
   render() {
     return (
       <Wrapper
@@ -294,6 +286,9 @@ class Dropdown extends Component {
   setFocusedOption(focusedOption) {
     this.setState({
       focusedOption,
+    });
+    scrollIntoView(this.options[focusedOption], {
+      validTarget: target => target.classList && target.classList.contains('flightbox-dropdown-options-container')
     });
   }
 


### PR DESCRIPTION
The automatic scrolling is only desired when navigating with the arrow
keys on the keyboard. In this case, we keep the scrolling. However,
it's not desired on every component update (which also occurs when
we move the cursor over the list of options -> no automatic scolling
desired in this case).