### PR TITLE
Fix matching of circuit movements for non-homebased aircrafts

### DIFF
--- a/src/modules/movements/associate.spec.js
+++ b/src/modules/movements/associate.spec.js
@@ -185,8 +185,8 @@ describe('modules', () => {
         const associations = getAssociations(movements.array, homeBaseAicrafts);
 
         expect(associations).toEqual({
-          arr1: null,
-          dep1: null
+          arr1: undefined,
+          dep1: undefined
         });
       });
 
@@ -223,6 +223,75 @@ describe('modules', () => {
             immatriculation: 'HBABC',
             date: '2017-05-21',
             time: '12:00',
+            type: 'arrival',
+            arrivalRoute: 'circuits'
+          }
+        });
+      });
+
+      it('should associate circuit movement with circuit movement and non-circuit with non-cuircuit', () => {
+        const movements = new ImmutableItemsArray([{
+          key: 'dep2',
+          immatriculation: 'HBEXT',
+          date: '2017-05-21',
+          time: '14:00',
+          type: 'departure',
+          departureRoute: 'south'
+        }, {
+          key: 'arr2',
+          immatriculation: 'HBEXT',
+          date: '2017-05-21',
+          time: '13:00',
+          type: 'arrival',
+          arrivalRoute: 'circuits'
+        }, {
+          key: 'dep1',
+          immatriculation: 'HBEXT',
+          date: '2017-05-21',
+          time: '12:00',
+          type: 'departure',
+          departureRoute: 'circuits'
+        }, {
+          key: 'arr1',
+          immatriculation: 'HBEXT',
+          date: '2017-05-21',
+          time: '11:00',
+          type: 'arrival',
+          arrivalRoute: 'south'
+        }]);
+
+        const associations = getAssociations(movements.array, homeBaseAicrafts);
+
+        expect(associations).toEqual({
+          dep2: {
+            key: 'arr1',
+            immatriculation: 'HBEXT',
+            date: '2017-05-21',
+            time: '11:00',
+            type: 'arrival',
+            arrivalRoute: 'south'
+          },
+          arr1: {
+            key: 'dep2',
+            immatriculation: 'HBEXT',
+            date: '2017-05-21',
+            time: '14:00',
+            type: 'departure',
+            departureRoute: 'south'
+          },
+          arr2: {
+            key: 'dep1',
+            immatriculation: 'HBEXT',
+            date: '2017-05-21',
+            time: '12:00',
+            type: 'departure',
+            departureRoute: 'circuits'
+          },
+          dep1: {
+            key: 'arr2',
+            immatriculation: 'HBEXT',
+            date: '2017-05-21',
+            time: '13:00',
             type: 'arrival',
             arrivalRoute: 'circuits'
           }

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -204,12 +204,7 @@ export function* loadAssociatedMovement(movement, homeBaseAircrafts, channel) {
 
   const isHomeBase = homeBaseAircrafts.has(movement.immatriculation);
 
-  const index = relevantMovements.array.findIndex(m => m.key === movement.key);
-
-  const preceding = relevantMovements.array[index + 1];
-  const subsequent = relevantMovements.array[index - 1];
-
-  const associatedMovement = getAssociatedMovement(movement, isHomeBase, preceding, subsequent) || null;
+  const associatedMovement = getAssociatedMovement(movement, isHomeBase, relevantMovements.array) || null;
 
   return {
     movement,


### PR DESCRIPTION
Circuit *departure* must always come before the *arrival* even though
not all aircrafts are homebased at the aerodrome.

Example flight order (aircraft homebased at different aerodrome):

1. 08:00 arrival from different aerodrome (should match with #4)
2. 09:00 departure for circuits (should match with #3)
3. 09:30 arrival from circuits (should match with #2)
4. 10:00 departure to different aerodrome (should match with #1)

See ticket (LSPV): https://app.asana.com/0/1201466020311786/1202612088125868/f