### PR TITLE
Instruct pilots to create departure *and* arrival for circuits

### DIFF
--- a/src/components/wizards/ArrivalWizard/pages/FlightPage.js
+++ b/src/components/wizards/ArrivalWizard/pages/FlightPage.js
@@ -7,6 +7,7 @@ import { renderSingleSelect, renderTextArea } from '../../renderField';
 import FieldSet from '../../FieldSet';
 import WizardNavigation from '../../../WizardNavigation';
 import {updateLandingFees, updateGoAroundFees, getAircraftOrigin} from '../../../../util/landingFees';
+import CircuitsFieldHint from '../../CircuitsFieldHint';
 
 const FlightPage = (props) => {
   const { previousPage, handleSubmit, flightTypes, arrivalRoutes, runways, formValues, aircraftSettings } = props;
@@ -41,6 +42,7 @@ const FlightPage = (props) => {
           parse={e => e.target.value}
           label="Ankunftsroute"
           readOnly={props.readOnly}
+          hint={props.arrivalRoute === 'circuits' && <CircuitsFieldHint/>}
         />
         <Field
           name="remarks"

--- a/src/components/wizards/CircuitsFieldHint.js
+++ b/src/components/wizards/CircuitsFieldHint.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import FieldHint, {Strong} from './FieldHint';
+
+const CircuitsFieldHint = () => (
+  <FieldHint caption="Bitte beachten">
+    <div>Bitte auch bei Platzrunden Abflug <Strong>und</Strong> Ankunft erfassen.</div>
+  </FieldHint>
+);
+
+export default CircuitsFieldHint;

--- a/src/components/wizards/DepartureWizard/pages/FlightPage.js
+++ b/src/components/wizards/DepartureWizard/pages/FlightPage.js
@@ -5,6 +5,7 @@ import validate from '../../validate';
 import { renderSingleSelect, renderTextArea } from '../../renderField';
 import FieldSet from '../../FieldSet';
 import WizardNavigation from '../../../WizardNavigation';
+import CircuitsFieldHint from '../../CircuitsFieldHint';
 
 const FlightPage = (props) => {
   const { previousPage, handleSubmit, flightTypes, runways, departureRoutes } = props;
@@ -37,6 +38,7 @@ const FlightPage = (props) => {
           parse={e => e.target.value}
           label="Abflugroute"
           readOnly={props.readOnly}
+          hint={props.departureRoute === 'circuits' && <CircuitsFieldHint/>}
         />
         <Field
           name="route"
@@ -79,6 +81,7 @@ FlightPage.propTypes = {
     value: PropTypes.string.isRequired,
     description: PropTypes.string,
   })).isRequired,
+  departureRoute: PropTypes.string,
   hiddenFields: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/src/components/wizards/FieldHint.js
+++ b/src/components/wizards/FieldHint.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+const Box = styled.div`
+  background-color: ${props => props.theme.colors.background};
+  margin: 0.5em 0;
+  padding: 0.5em;
+  box-sizing: border-box;
+`;
+
+const Caption = styled.div`
+  font-size: 0.8em;
+  margin-bottom: 1em;
+  color: ${props => props.theme.colors.danger};
+`;
+
+export const Strong = styled.span`
+  color: ${props => props.theme.colors.danger};
+`
+
+export const Children = styled.div`
+  font-size: 0.7em;
+`
+
+const FieldHint = props => (
+  <Box>
+    <Caption>{props.caption}:</Caption>
+    <Children>{props.children}</Children>
+  </Box>
+)
+
+FieldHint.propTypes = {
+  caption: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ])
+};
+
+export default FieldHint;

--- a/src/components/wizards/renderField.js
+++ b/src/components/wizards/renderField.js
@@ -56,13 +56,16 @@ export const renderInputField = (props) => {
 
 export const renderSingleSelect = (props) => {
   const cmp = (
-    <SingleSelect
-      {...props.input}
-      items={props.items}
-      orientation={props.orientation}
-      readOnly={props.readOnly}
-      dataCy={props.input.name}
-    />
+    <>
+      <SingleSelect
+        {...props.input}
+        items={props.items}
+        orientation={props.orientation}
+        readOnly={props.readOnly}
+        dataCy={props.input.name}
+      />
+      {props.hint}
+    </>
   );
   return renderLabeledComponent(props, cmp);
 };

--- a/src/containers/ArrivalFlightPageContainer.js
+++ b/src/containers/ArrivalFlightPageContainer.js
@@ -30,7 +30,8 @@ const mapStateToProps = (state, ownProps) => {
     flightTypes: filter(getEnabledFlightTypes(), values),
     runways: filter(runways, values),
     arrivalRoutes: filter(arrivalRoutes, values),
-    hiddenFields: getHiddenFields(values)
+    hiddenFields: getHiddenFields(values),
+    arrivalRoute: values.arrivalRoute
   });
 };
 

--- a/src/containers/DepartureFlightPageContainer.js
+++ b/src/containers/DepartureFlightPageContainer.js
@@ -30,7 +30,8 @@ const mapStateToProps = (state, ownProps) => {
     flightTypes: filter(getEnabledFlightTypes(), values),
     runways: filter(runways, values),
     departureRoutes: filter(departureRoutes, values),
-    hiddenFields: getHiddenFields(values)
+    hiddenFields: getHiddenFields(values),
+    departureRoute: values.departureRoute
   });
 };
 


### PR DESCRIPTION
Sometimes pilots only create either a departure or an arrival record
for circuit movements. However, we need both records for circuits as
well. Therefore, we now display a hint next to the route field when
"circuits" is selected.

See ticket (LSPV): https://app.asana.com/0/1201466020311786/1202612088125873/f