### PR TITLE
Add filtering options for movements (only for admins)

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -46,6 +46,7 @@ class Button extends React.Component {
           disabled={disabled}
           hovered={this.state.hovered}
           danger={danger}
+          flat={flat}
         >
           {icon && <MaterialIcon icon={icon}/>}<Label>{label}</Label>
         </Overlay>

--- a/src/components/Button/Overlay.js
+++ b/src/components/Button/Overlay.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
 const getBackgroundColor = props =>
-  props.danger
+  props.danger && !props.flat
     ? `rgba(0, 0, 0, 1.0)`
     : `rgba(255, 255, 255, 0.2)`;
 
 const Overlay = styled.div`
   padding: 12px;
-  
+
   ${props => !props.disabled && props.hovered && `
     transition: all 300ms cubic-bezier(0.445, 0.05, 0.55, 0.95) 0ms;
     background-color: ${getBackgroundColor(props)}

--- a/src/components/Button/StyledButton.js
+++ b/src/components/Button/StyledButton.js
@@ -9,7 +9,10 @@ const colors = props => {
   }
 
   if (props.danger) {
-    return `
+    return props.flat ? `
+      background-color: #fff;
+      color: ${props.theme.colors.danger};
+    ` : `
       background-color: ${props.disabled ? `#ccc` : props.theme.colors.danger};
       color: #fff;
     `;

--- a/src/components/MovementFilter/MovementFilter.js
+++ b/src/components/MovementFilter/MovementFilter.js
@@ -1,0 +1,191 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import moment from 'moment';
+import Button from '../Button';
+import DatePicker from '../DatePicker';
+import Input from '../Input';
+import LabeledComponent from '../LabeledComponent';
+import MaterialIcon from '../MaterialIcon';
+
+const StyledContainer = styled.div`
+  background-color: #fbfbfb;
+  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24);
+  margin-bottom: 1em;
+  position: relative;
+`;
+
+const StyledButton = styled(Button)`
+  background-color: #fbfbfb;
+  width: 100%;
+  text-align: left;
+`;
+
+const CheckboxWrapper = styled.div`
+  padding: 1em;
+`;
+
+const StyledDateComponent = styled(LabeledComponent)`
+  padding: 1em;
+  box-sizing: border-box;
+  display: inline-block;
+  width: 50%;
+`;
+
+const StyledInput = styled(LabeledComponent)`
+  padding: 1em;
+`;
+
+const ClearButton = styled.button`
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  position: absolute;
+  top: 15px;
+  right: 10px;
+`;
+
+const renderDatePicker = (value, onChange) => (
+  <DatePicker
+    value={value ? moment(value).format('YYYY-MM-DD') : null}
+    onChange={(e) => {
+      const ms = e.value ? new Date(e.value).getTime() : null;
+      onChange(ms);
+    }}
+    clearable
+  />
+);
+
+const renderInput = (value, onChange, disabled) => (
+  <Input value={value} onChange={onChange} disabled={disabled}/>
+)
+
+const renderCheckbox = (value, onChange, disabled) => (
+  <CheckboxWrapper>
+    <label>
+      <Input
+        type="checkbox"
+        checked={value}
+        onChange={onChange}
+        disabled={disabled}
+      />
+      Nur Bewegungen ohne zugeordnete Gegenbewegung anzeigen
+    </label>
+  </CheckboxWrapper>
+)
+
+const handleStartDateChange = (currentFilter, onChange) => newValue => {
+  onChange({
+    ...currentFilter,
+    date: {
+      ...currentFilter.date,
+      start: newValue,
+    }
+  })
+}
+
+const handleEndDateChange = (currentFilter, onChange) => newValue => {
+  onChange({
+    ...currentFilter,
+    date: {
+      ...currentFilter.date,
+      end: newValue,
+    }
+  })
+}
+
+const handleImmatriculationChange = (currentFilter, onChange) => e => {
+  onChange({
+    ...currentFilter,
+    immatriculation: e.target.value.toUpperCase()
+  })
+}
+
+const handleOnlyWithoutAssociatedMovementChange = (currentFilter, onChange) => e => {
+  onChange({
+    ...currentFilter,
+    onlyWithoutAssociatedMovement: e.target.checked
+  })
+}
+
+const handleFilterClick = (expanded, setExpanded) => () => {
+  setExpanded(!expanded);
+}
+
+const handleClear = setMovementsFilter => () => {
+  setMovementsFilter({
+    date: {
+      start: null,
+      end: null
+    },
+    immatriculation: '',
+    onlyWithoutAssociatedMovement: false
+  })
+}
+
+const MovementFilter = ({filter, expanded, setMovementsFilter, setExpanded}) => {
+  const dateFilterSet = !!filter.date.start && !!filter.date.end
+  return (
+    <StyledContainer>
+      <StyledButton
+        icon="filter_list"
+        label={dateFilterSet ? "Filter (aktiv)" : "Filter"}
+        onClick={handleFilterClick(expanded, setExpanded)}
+        danger={dateFilterSet}
+        flat
+      />
+      {(expanded || dateFilterSet) && (
+        <ClearButton onClick={handleClear(setMovementsFilter)}>
+          <MaterialIcon icon="clear"/>
+        </ClearButton>
+      )}
+      {expanded && (
+        <div>
+          <div>
+            <StyledDateComponent
+              label="Startdatum"
+              component={renderDatePicker(filter.date.start, handleStartDateChange(filter, setMovementsFilter))}
+              validationError={!filter.date.start && filter.date.end ? 'Bitte Startdatum setzen' : null}
+            />
+            <StyledDateComponent
+              label="Enddatum"
+              component={renderDatePicker(filter.date.end, handleEndDateChange(filter, setMovementsFilter))}
+              validationError={!filter.date.end && filter.date.start ? 'Bitte Enddatum setzen' : null}
+            />
+          </div>
+          <StyledInput label="Immatrikulation"
+                       component={renderInput(
+                         filter.immatriculation,
+                         handleImmatriculationChange(filter, setMovementsFilter),
+                         !dateFilterSet
+                       )}
+                       validationError={filter.immatriculation.length > 0 && filter.immatriculation.length < 3
+                         ? 'Bitte mindestens 3 Zeichen eingeben'
+                         : null}
+          />
+          {renderCheckbox(
+            filter.onlyWithoutAssociatedMovement,
+            handleOnlyWithoutAssociatedMovementChange(filter, setMovementsFilter),
+            !dateFilterSet
+          )}
+        </div>
+      )}
+    </StyledContainer>
+  );
+}
+
+MovementFilter.propTypes = {
+  filter: PropTypes.shape({
+    date: PropTypes.shape({
+      start: PropTypes.number,
+      end: PropTypes.number,
+    }).isRequired,
+    immatriculation: PropTypes.string
+  }).isRequired,
+  expanded: PropTypes.bool.isRequired,
+  setExpanded: PropTypes.func.isRequired,
+  setMovementsFilter: PropTypes.func.isRequired
+}
+
+export default MovementFilter;

--- a/src/components/MovementFilter/index.js
+++ b/src/components/MovementFilter/index.js
@@ -1,0 +1,3 @@
+import MovementFilter from './MovementFilter';
+
+export default MovementFilter;

--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import Predicates from './Predicates';
 import MovementGroup from './MovementGroup';
 import LoadingInfo from './LoadingInfo';
 import LoadingFailureInfo from './LoadingFailureInfo';
+import NoMovementsInfo from './NoMovmementsInfo';
 import MovementDeleteConfirmationDialog from '../MovementDeleteConfirmationDialog';
 import { AutoLoad } from '../../util/AutoLoad';
-import dates from '../../util/dates';
+import MovementFilter from '../../containers/MovementFilterContainer';
 
 const afterTodayPredicate = Predicates.newerThanSameDay();
 const todayPredicate = Predicates.sameDay();
@@ -52,6 +53,7 @@ class MovementList extends React.PureComponent {
 
     return (
       <div>
+        {this.props.isAdmin === true && <MovementFilter/>}
         <MovementGroup
           label="Ab morgen"
           items={this.props.items}
@@ -127,6 +129,7 @@ class MovementList extends React.PureComponent {
         />
         {this.props.loading && <LoadingInfo/>}
         {this.props.loadingFailed && <LoadingFailureInfo/>}
+        {!this.props.loading && this.props.items.array.length === 0 && <NoMovementsInfo/>}
         {confirmationDialog}
       </div>
     );
@@ -152,7 +155,8 @@ MovementList.propTypes = {
   aircraftSettings: PropTypes.shape({
     club: PropTypes.objectOf(PropTypes.bool),
     homeBase: PropTypes.objectOf(PropTypes.bool)
-  }).isRequired
+  }).isRequired,
+  isAdmin: PropTypes.bool
 };
 
 export default AutoLoad(MovementList);

--- a/src/components/MovementList/NoMovmementsInfo.js
+++ b/src/components/MovementList/NoMovmementsInfo.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  text-align: center;
+  color: ${props => props.theme.colors.danger}
+`;
+
+const NoMovementsInfo = () => (
+  <Wrapper>Keine Bewegungen gefunden.</Wrapper>
+);
+
+export default NoMovementsInfo;

--- a/src/containers/MovementFilterContainer.js
+++ b/src/containers/MovementFilterContainer.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { setMovementsFilter } from '../modules/movements';
+import { setMovementsFilterExpanded } from '../modules/ui/movements';
+
+import MovementFilter from '../components/MovementFilter';
+
+const mapStateToProps = state => {
+  return ({
+    filter: state.movements.filter,
+    expanded: state.ui.movements.filterExpanded
+  });
+}
+
+const mapActionCreators = {
+  setMovementsFilter,
+  setExpanded: setMovementsFilterExpanded
+};
+
+export default connect(mapStateToProps, mapActionCreators)(MovementFilter);

--- a/src/containers/MovementListContainer.js
+++ b/src/containers/MovementListContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { loadMovements, monitorMovements, deleteMovement } from '../modules/movements';
+import { loadMovements, deleteMovement } from '../modules/movements';
 import {
   showDeleteConfirmationDialog,
   hideDeleteConfirmationDialog,
@@ -10,17 +10,52 @@ import {
 import { loadAircraftSettings } from '../modules/settings/aircrafts'
 
 import MovementList from '../components/MovementList';
+import ImmutableItemsArray from '../util/ImmutableItemsArray';
+
+const getMovements = state => {
+  const data = state.movements.data;
+  const associatedMovements = state.movements.associatedMovements;
+  const filter = state.movements.filter;
+
+  const dateFilterSet = !!filter.date.start && !!filter.date.end
+
+  if (!dateFilterSet) {
+    return data;
+  }
+
+  const immatriculationFilter = state.movements.filter.immatriculation;
+  const onlyWithoutAssociatedMovement = state.movements.filter.onlyWithoutAssociatedMovement;
+
+  if (immatriculationFilter && immatriculationFilter.length >= 3 || onlyWithoutAssociatedMovement) {
+    const filteredData = data.array.filter(item => {
+      if (immatriculationFilter && immatriculationFilter.length >= 3 && !item.immatriculation.includes(immatriculationFilter)) {
+        return false;
+      }
+      if (onlyWithoutAssociatedMovement) {
+        if (associatedMovements[item.key]) {
+          return false;
+        }
+      }
+      return true;
+    });
+    return new ImmutableItemsArray(filteredData);
+  }
+
+  return data;
+};
 
 const mapStateToProps = state => {
   return {
-    items: state.movements.data,
+    items: getMovements(state),
     associatedMovements: state.movements.associatedMovements,
     loading: state.movements.loading,
     loadingFailed: state.movements.loadingFailed,
     lockDate: state.settings.lockDate,
     aircraftSettings: state.settings.aircrafts,
     deleteConfirmation: state.ui.movements.deleteConfirmation,
-    selected: state.ui.movements.selected
+    selected: state.ui.movements.selected,
+    autoLoadDisabled: state.movements.filter.date.start && state.movements.filter.date.end,
+    isAdmin: state.auth.data.admin
   };
 };
 

--- a/src/modules/movements/actions.js
+++ b/src/modules/movements/actions.js
@@ -19,6 +19,7 @@ export const SAVE_MOVEMENT_FAILED = 'SAVE_MOVEMENT_FAILED';
 export const EDIT_MOVEMENT = 'EDIT_MOVEMENT';
 export const START_INITIALIZE_WIZARD = 'START_INITIALIZE_WIZARD';
 export const WIZARD_INITIALIZED = 'WIZARD_INITIALIZED';
+export const SET_MOVEMENTS_FILTER = 'SET_MOVEMENTS_FILTER';
 
 export function loadMovements(clear) {
   return {
@@ -204,5 +205,14 @@ export function startInitializeWizard() {
 export function wizardInitialized() {
   return {
     type: WIZARD_INITIALIZED,
+  };
+}
+
+export function setMovementsFilter(filter) {
+  return {
+    type: SET_MOVEMENTS_FILTER,
+    payload: {
+      filter
+    }
   };
 }

--- a/src/modules/movements/index.js
+++ b/src/modules/movements/index.js
@@ -11,7 +11,8 @@ export {
   initNewMovement,
   initNewMovementFromMovement,
   editMovement,
-  saveMovement
+  saveMovement,
+  setMovementsFilter
 } from './actions';
 
 export { sagas };

--- a/src/modules/movements/reducer.js
+++ b/src/modules/movements/reducer.js
@@ -38,12 +38,18 @@ export const setMovementsByImmatriculation = (state, action) => ({
   }
 });
 
+export const setFilter = (state, action) => ({
+  ...state,
+  filter: action.payload.filter
+})
+
 const ACTION_HANDLERS = {
   [actions.SET_MOVEMENTS]: setMovements,
   [actions.SET_ASSOCIATED_MOVEMENTS]: setAssociatedMovements,
   [actions.SET_MOVEMENTS_BY_IMMATRICULATION]: setMovementsByImmatriculation,
   [actions.SET_MOVEMENTS_LOADING]: setLoading,
   [actions.LOAD_MOVEMENTS_FAILURE]: setLoadingFailure,
+  [actions.SET_MOVEMENTS_FILTER]: setFilter,
 };
 
 const INITIAL_STATE = {
@@ -52,6 +58,14 @@ const INITIAL_STATE = {
   loadingFailed: false,
   associatedMovements: {},
   byImmatriculation: {},
+  filter: {
+    date: { // "end" is the newer date bound ("start" must come before "end")
+      start: null,
+      end: null
+    },
+    immatriculation: '',
+    onlyWithoutAssociatedMovement: false
+  }
 };
 
 const reducer = (initialState, actionHandlers) => {

--- a/src/modules/movements/reducer.spec.js
+++ b/src/modules/movements/reducer.spec.js
@@ -1,10 +1,32 @@
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
 import * as actions from './actions';
-import * as reducer from './reducer';
+import reducer from './reducer';
+
+const INITIAL_STATE = {
+  data: new ImmutableItemsArray(),
+  loading: false,
+  loadingFailed: false,
+  associatedMovements: {},
+  byImmatriculation: {},
+  filter: {
+    date: { // "end" is the newer date bound ("start" must come before "end")
+      start: null,
+      end: null
+    },
+    immatriculation: '',
+    onlyWithoutAssociatedMovement: false
+  }
+};
 
 describe('modules', () => {
   describe('movements', () => {
     describe('reducers', () => {
+      it('should handle initial state', () => {
+        expect(
+          reducer(undefined, {})
+        ).toEqual(INITIAL_STATE);
+      });
+
       describe('setMovements', () => {
         it('should set movements', () => {
           const state = {
@@ -52,7 +74,7 @@ describe('modules', () => {
 
           const action = actions.setMovements(newMovements);
 
-          const newState = reducer.setMovements(state, action);
+          const newState = reducer(state, action);
 
           expect(newState.loading).toEqual(false);
           expect(newState.data).toEqual(newMovements);

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -102,6 +102,10 @@ export function getOldest(snapshot) {
   return oldest;
 }
 
+export function* filterMovements() {
+  yield put(actions.loadMovements(true));
+}
+
 export function* loadMovements(channel, action) {
   try {
     const {clear} = action.payload;
@@ -110,33 +114,7 @@ export function* loadMovements(channel, action) {
     if (movements.loading !== true) {
       yield put(actions.setMovementsLoading());
 
-      const pagination = getPagination(clear ? [] : movements.data.array);
-
-      const departures = yield call(
-        remote.loadLimited,
-        '/departures',
-        pagination.start,
-        pagination.limit
-      );
-
-      const oldestDeparture = getOldest(departures.snapshot);
-
-      let arrivalsLimit = null;
-      let arrivalsEnd = null;
-
-      if (oldestDeparture) {
-        arrivalsEnd = oldestDeparture.negativeTimestamp;
-      } else {
-        arrivalsLimit = pagination.limit;
-      }
-
-      const arrivals = yield call(
-        remote.loadLimited,
-        '/arrivals',
-        pagination.start,
-        arrivalsLimit,
-        arrivalsEnd
-      );
+      const { departures, arrivals } = yield call(loadDeparturesAndArrivals, movements, clear);
 
       const eventActions = {
         added: actions.movementAdded,
@@ -155,6 +133,71 @@ export function* loadMovements(channel, action) {
     error('Failed to load movements', e);
     channel.put(actions.loadMovementsFailure());
   }
+}
+
+export function* loadDeparturesAndArrivals(movements, clear) {
+  if (movements.filter.date.start && movements.filter.date.end) {
+    return yield call(loadDeparturesAndArrivalsFiltered, movements);
+  } else {
+    return yield call(loadLatestDeparturesAndArrivalsPaged, movements, clear);
+  }
+}
+
+export function* loadDeparturesAndArrivalsFiltered(movements) {
+  // start and end is the other way round because we're sorting (ascending) by negative timestamp
+  // (we can't fetch data sorted descending in firebase)
+  const start = dates.negativeTimestampEndOfDay(movements.filter.date.end);
+  const end = dates.negativeTimestampStartOfDay(movements.filter.date.start);
+
+  const departures = yield call(
+    remote.loadLimited,
+    '/departures',
+    start,
+    null,
+    end
+  );
+
+  const arrivals = yield call(
+    remote.loadLimited,
+    '/arrivals',
+    start,
+    null,
+    end
+  );
+
+  return {departures, arrivals};
+}
+
+export function* loadLatestDeparturesAndArrivalsPaged(movements, clear) {
+  const pagination = getPagination(clear ? [] : movements.data.array);
+
+  const departures = yield call(
+    remote.loadLimited,
+    '/departures',
+    pagination.start,
+    pagination.limit
+  );
+
+  const oldestDeparture = getOldest(departures.snapshot);
+
+  let arrivalsLimit = null;
+  let arrivalsEnd = null;
+
+  if (oldestDeparture) {
+    arrivalsEnd = oldestDeparture.negativeTimestamp;
+  } else {
+    arrivalsLimit = pagination.limit;
+  }
+
+  const arrivals = yield call(
+    remote.loadLimited,
+    '/arrivals',
+    pagination.start,
+    arrivalsLimit,
+    arrivalsEnd
+  );
+
+  return {departures, arrivals};
 }
 
 export function* getHomeBaseAircrafts() {
@@ -506,6 +549,7 @@ export default function* sagas() {
   yield [
     fork(monitor, channel),
     fork(takeEvery, actions.LOAD_MOVEMENTS, loadMovements, channel),
+    fork(takeEvery, actions.SET_MOVEMENTS_FILTER, filterMovements, channel),
     fork(takeEvery, actions.SET_MOVEMENTS, associateMovements, channel),
     fork(takeEvery, actions.MOVEMENT_ADDED, movementAdded, channel),
     fork(takeEvery, actions.MOVEMENT_CHANGED, movementChanged, channel),

--- a/src/modules/ui/movements/actions.js
+++ b/src/modules/ui/movements/actions.js
@@ -4,6 +4,7 @@ export const SHOW_MOVEMENT_WIZARD = 'SHOW_MOVEMENT_WIZARD';
 export const CREATE_MOVEMENT_FROM_MOVEMENT = 'CREATE_MOVEMENT_FROM_MOVEMENT';
 export const CANCEL_WIZARD = 'CANCEL_WIZARD';
 export const SELECT_MOVEMENT = 'SELECT_MOVEMENT';
+export const SET_MOVEMENTS_FILTER_EXPANDED = 'SET_MOVEMENTS_FILTER_EXPANDED';
 
 export function showDeleteConfirmationDialog(item) {
   return {
@@ -51,6 +52,15 @@ export function selectMovement(key) {
     type: SELECT_MOVEMENT,
     payload: {
       key,
+    }
+  }
+}
+
+export function setMovementsFilterExpanded(expanded) {
+  return {
+    type: SET_MOVEMENTS_FILTER_EXPANDED,
+    payload: {
+      expanded,
     }
   }
 }

--- a/src/modules/ui/movements/index.js
+++ b/src/modules/ui/movements/index.js
@@ -7,7 +7,8 @@ export {
   showMovementWizard,
   createMovementFromMovement,
   cancelWizard,
-  selectMovement
+  selectMovement,
+  setMovementsFilterExpanded
 } from './actions';
 
 export { sagas };

--- a/src/modules/ui/movements/reducer.js
+++ b/src/modules/ui/movements/reducer.js
@@ -19,15 +19,24 @@ function selectMovement(state, action) {
   });
 }
 
+function setMovementsFilterExpanded(state, action) {
+  return {
+    ...state,
+    filterExpanded: action.payload.expanded
+  };
+}
+
 const ACTION_HANDLERS = {
   [actions.SHOW_DELETE_CONFIRMATION_DIALOG]: showDeleteConfirmationDialog,
   [actions.HIDE_DELETE_CONFIRMATION_DIALOG]: hideDeleteConfirmationDialog,
   [actions.SELECT_MOVEMENT]: selectMovement,
+  [actions.SET_MOVEMENTS_FILTER_EXPANDED]: setMovementsFilterExpanded,
 };
 
 const INITIAL_STATE = {
   deleteConfirmation: null,
   selected: null,
+  filterExpanded: false
 };
 
 export default reducer(INITIAL_STATE, ACTION_HANDLERS);

--- a/src/modules/ui/movements/reducer.spec.js
+++ b/src/modules/ui/movements/reducer.spec.js
@@ -4,6 +4,7 @@ import * as actions from './actions';
 const INITIAL_STATE = {
   deleteConfirmation: null,
   selected: null,
+  filterExpanded: false
 };
 
 describe('modules', () => {
@@ -44,6 +45,18 @@ describe('modules', () => {
               }, actions.selectMovement(null))
             ).toEqual({
               selected: null
+            });
+          });
+        });
+
+        describe('SET_MOVEMENTS_FILTER_EXPANDED', () => {
+          it('should set the expanded flag', () => {
+            expect(
+              reducer({
+                filterExpanded: false
+              }, actions.setMovementsFilterExpanded(true))
+            ).toEqual({
+              filterExpanded: true
             });
           });
         });

--- a/src/util/AutoLoad.js
+++ b/src/util/AutoLoad.js
@@ -46,7 +46,7 @@ export const AutoLoad = (List) => class extends Component {
   }
 
   handleScroll(e) {
-    if (this.isEndReached(e.target)) {
+    if (this.isEndReached(e.target) && !this.props.autoLoadDisabled) {
       this.props.loadItems();
     }
   }
@@ -80,4 +80,5 @@ AutoLoad.propTypes = {
   items: PropTypes.array.isRequired,
   bottomThreshold: PropTypes.number,
   className: PropTypes.string,
+  autoLoadDisabled: PropTypes.bool,
 };

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -29,6 +29,14 @@ const dates = {
     return new Date(isoUtc).getTime();
   },
 
+  negativeTimestampStartOfDay(localDateString) {
+    return moment.tz(localDateString, 'Europe/Zurich').startOf('day').valueOf() * -1;
+  },
+
+  negativeTimestampEndOfDay(localDateString) {
+    return moment.tz(localDateString, 'Europe/Zurich').endOf('day').valueOf() * -1;
+  },
+
   /**
    * @param localDateString optional local date string (for timezone 'Europe/Zurich'; if missing: now)
    */


### PR DESCRIPTION
- Movements can be filtered by dates now (start *and* end date must be
  selected)
- If date range is selected, the entire range is loaded. So be careful
  with big amounts of data as they're not loaded paged in this case.
- Once a date range has been selected, the displayed movements can
  be further narrowed down to only show certain immatriculations
  or only show those movements without a associated movement
- The filtering form is only available for admins

See tickets (LSPV):
- https://app.asana.com/0/1201466020311786/1201468389987023/f
- https://app.asana.com/0/1201466020311786/1201468389987012/f