### PR TITLE
Fix movement association if filtered with circuits

### DIFF
--- a/src/modules/movements/associate.js
+++ b/src/modules/movements/associate.js
@@ -53,7 +53,7 @@ const addAssociatedMovement = (aircraftMovements, predicate, associations, isHom
   })
 }
 
-const isCircuit = movement => {
+export const isCircuit = movement => {
   const route = movement.departureRoute || movement.arrivalRoute;
   return route === 'circuits';
 }

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -9,7 +9,7 @@ import {localToFirebase, firebaseToLocal, transferValues, compareDescending} fro
 import { error } from '../../util/log';
 import dates from '../../util/dates';
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
-import getAssociations, {getAssociatedMovement} from './associate';
+import getAssociations, {getAssociatedMovement, isCircuit} from './associate';
 import firebase from '../../util/firebase';
 
 export const stateSelector = state => state.movements;
@@ -243,11 +243,14 @@ export function* loadAssociatedMovements(movements, homeBaseAircrafts, channel) 
 }
 
 export function* loadAssociatedMovement(movement, homeBaseAircrafts, channel) {
-  const relevantMovements = yield call(getMovementsByImmatriculation, movement.immatriculation, channel);
+  const aircraftMovements = yield call(getMovementsByImmatriculation, movement.immatriculation, channel);
+
+  const expectCircuit = isCircuit(movement);
+  const relevantMovements = aircraftMovements.array.filter(movement => expectCircuit === isCircuit(movement))
 
   const isHomeBase = homeBaseAircrafts.has(movement.immatriculation);
 
-  const associatedMovement = getAssociatedMovement(movement, isHomeBase, relevantMovements.array) || null;
+  const associatedMovement = getAssociatedMovement(movement, isHomeBase, relevantMovements) || null;
 
   return {
     movement,


### PR DESCRIPTION
Example movement sequence of *non-homebased* aircraft:
1. arrival
2. circuits departure
3. circuits arrival
4. departure

Here, movements 1 and 4 are associated and movements 2 and 3.
However if we set the date filtering so that movements 1 to 3
were visible or 2 to 4, the matching counterpart for movement 1
resp. 4 couldn't be found. The reason was that we didn't filter
out the circuit movements in between in this case. Now the issue
is fixed.