### PR TITLE
Disable payment method "paylink" as not fully implemented yet

### DIFF
--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
@@ -3,21 +3,25 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {Step} from '../../../../modules/ui/arrivalPayment'
 import SingleSelect from '../../../SingleSelect'
-import {NextButton, CancelButton} from '../../../WizardNavigation'
+import {CancelButton, NextButton} from '../../../WizardNavigation'
 import CashPaymentMessage from './CashPaymentMessage'
 import FinishActions from './FinishActions'
 
 const PAYMENT_METHODS = [{
-  label: 'Karte',
-  value: 'card'
-}, {
-  label: 'Zahlung per Bezahl-Link (E-Mail)',
-  value: 'paylink'
-}
-  /*{
+    label: 'Karte',
+    value: 'card'
+  },
+  /*
+  disabled for now as not fully implemented (payment service connection)
+  {
+    label: 'Zahlung per Bezahl-Link (E-Mail)',
+    value: 'paylink'
+  }
+  */
+  {
     label: 'Bar',
     value: 'cash'
-  }*/]
+  }]
 
 const Container = styled.div`
   padding: 2em;


### PR DESCRIPTION
- Disabling because we still need to be able to ship dev to prod (functions needs runtime upgrade from Node 10 to Node 20, because Node 10 will be decomissioned by the end of January 2025)
- Once the implementation of the paylink payment method has been completed, we can reenable it.