### PR TITLE
Mask email and phone in movement list for non-admins

### DIFF
--- a/src/components/MovementList/AssociatedMovement.js
+++ b/src/components/MovementList/AssociatedMovement.js
@@ -86,7 +86,7 @@ class AssociatedMovement extends React.PureComponent {
           <Label>{label}</Label>
           {text && <div>{text}</div>}
           {associatedMovementData
-            ? <StyledDetails data={associatedMovementData} isHomeBase={this.props.isHomeBase}/>
+            ? <StyledDetails data={associatedMovementData} isHomeBase={this.props.isHomeBase} isAdmin={this.props.isAdmin}/>
             : associatedMovementData === undefined
               ? <MaterialIcon icon="sync" rotate="left"/>
               : (

--- a/src/components/MovementList/Movement.js
+++ b/src/components/MovementList/Movement.js
@@ -64,6 +64,7 @@ class Movement extends React.PureComponent {
               data={props.data}
               locked={props.locked}
               isHomeBase={isHomeBase}
+              isAdmin={props.isAdmin}
             />
             {!props.locked && (
               <Footer>
@@ -81,6 +82,7 @@ class Movement extends React.PureComponent {
               associatedMovement={props.data.associatedMovement}
               createMovementFromMovement={props.createMovementFromMovement}
               loading={props.loading}
+              isAdmin={props.isAdmin}
             />
           </div>
         )}

--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import {getLabel as getFlightTypeLabel} from '../../util/flightTypes';
-import {getDepartureRouteLabel, getArrivalRouteLabel} from '../../util/routes';
+import {getArrivalRouteLabel, getDepartureRouteLabel} from '../../util/routes';
 import {getItemLabel as getCarriageVoucherItemLabel} from '../../util/carriageVoucher';
 import newLineToBr from '../../util/newLineToBr';
 import DetailsBox from './DetailsBox';
@@ -11,6 +11,7 @@ import MovementField from './MovementField';
 import HomeBaseIcon from './HomeBaseIcon';
 import {getFromItemKey} from '../../util/reference-number';
 import {getLandingFeeText} from '../../util/landingFees';
+import {maskEmail, maskPhone} from '../../util/masking'
 
 const Content = styled.div`
   padding: 1.5em 1em 0 1em;
@@ -63,8 +64,8 @@ class MovementDetails extends React.PureComponent {
             <MovementField label="Mitgliedernummer" value={props.data.memberNr}/>
             <MovementField label="Nachname" value={props.data.lastname}/>
             <MovementField label="Vorname" value={props.data.firstname}/>
-            <MovementField label="E-Mail" value={props.data.email}/>
-            <MovementField label="Telefon" value={props.data.phone}/>
+            <MovementField label="E-Mail" value={props.isAdmin ? props.data.email : maskEmail(props.data.email)}/>
+            <MovementField label="Telefon" value={props.isAdmin ? props.data.phone : maskPhone(props.data.phone)}/>
           </DetailsBox>
           {props.data.type === 'departure'
             ? (
@@ -129,7 +130,8 @@ MovementDetails.propTypes = {
   className: PropTypes.string,
   data: PropTypes.object.isRequired,
   locked: PropTypes.bool,
-  isHomeBase: PropTypes.bool.isRequired
+  isHomeBase: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired
 };
 
 export default MovementDetails;

--- a/src/components/MovementList/MovementGroup.js
+++ b/src/components/MovementList/MovementGroup.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import Movement from './Movement';
-import { isLocked } from '../../util/movements.js';
+import {isLocked} from '../../util/movements.js';
 
 const GroupWrapper = styled.div`
   margin: 0 0 2em 0;
@@ -43,6 +43,7 @@ class MovementGroup extends React.PureComponent {
               locked={isLocked(item, props.lockDate)}
               aircraftSettings={props.aircraftSettings}
               loading={props.loading}
+              isAdmin={props.isAdmin}
             />
           )}
         </ItemsContainer>
@@ -66,7 +67,8 @@ MovementGroup.propTypes = {
     club: PropTypes.objectOf(PropTypes.bool),
     homeBase: PropTypes.objectOf(PropTypes.bool)
   }).isRequired,
-  loading: PropTypes.bool.isRequired
+  loading: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired
 };
 
 export default MovementGroup;

--- a/src/components/MovementList/MovementList.js
+++ b/src/components/MovementList/MovementList.js
@@ -6,7 +6,7 @@ import LoadingInfo from './LoadingInfo';
 import LoadingFailureInfo from './LoadingFailureInfo';
 import NoMovementsInfo from './NoMovmementsInfo';
 import MovementDeleteConfirmationDialog from '../MovementDeleteConfirmationDialog';
-import { AutoLoad } from '../../util/AutoLoad';
+import {AutoLoad} from '../../util/AutoLoad';
 import MovementFilter from '../../containers/MovementFilterContainer';
 
 const afterTodayPredicate = Predicates.newerThanSameDay();
@@ -67,6 +67,7 @@ class MovementList extends React.PureComponent {
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
           loading={this.props.loading}
+          isAdmin={this.props.isAdmin}
         />
         <MovementGroup
           label="Heute"
@@ -81,6 +82,7 @@ class MovementList extends React.PureComponent {
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
           loading={this.props.loading}
+          isAdmin={this.props.isAdmin}
         />
         <MovementGroup
           label="Gestern"
@@ -95,6 +97,7 @@ class MovementList extends React.PureComponent {
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
           loading={this.props.loading}
+          isAdmin={this.props.isAdmin}
         />
         <MovementGroup
           label="Dieser Monat"
@@ -108,6 +111,7 @@ class MovementList extends React.PureComponent {
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
           loading={this.props.loading}
+          isAdmin={this.props.isAdmin}
         />
         <MovementGroup
           label="Älter"
@@ -121,6 +125,7 @@ class MovementList extends React.PureComponent {
           lockDate={this.props.lockDate.date}
           aircraftSettings={this.props.aircraftSettings}
           loading={this.props.loading}
+          isAdmin={this.props.isAdmin}
         />
         {this.props.loading && <LoadingInfo/>}
         {this.props.loadingFailed && <LoadingFailureInfo/>}

--- a/src/util/masking.js
+++ b/src/util/masking.js
@@ -1,0 +1,21 @@
+export function maskEmail(email) {
+  if (!email) {
+    return email
+  }
+
+  const [localPart, domain] = email.split('@')
+  const maskedLocal = localPart[0] + '*'.repeat(localPart.length - 2) + localPart.slice(-1)
+  const [domainName, tld] = domain.split('.')
+  const maskedDomain = domainName[0] + '*'.repeat(domainName.length - 2) + domainName.slice(-1) + '.' + tld
+  return `${maskedLocal}@${maskedDomain}`
+}
+
+export function maskPhone(phone) {
+  if (!phone) {
+    return phone
+  }
+
+  const visibleDigits = 2
+  const maskedLength = phone.length - visibleDigits
+  return '*'.repeat(maskedLength) + phone.slice(-visibleDigits)
+}


### PR DESCRIPTION
- This is sensitive personal information which shouldn't be visible to everybody
- "Masking" means that the major part of the information is replaced with asterisks (*) and only a few letters or digits are still visible as plain text (just enough to recognize your own data)
- Admins can still see everything as plain text
- Will also have to be done in the edit form when an existing movement record is edited