### PR TITLE
Move `associatedMovement` field on movements to separate collection

### DIFF
--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -165,6 +165,10 @@
         }
       }
     },
+    "movementAssociations": {
+      ".read": "auth !== null",
+      ".write": false
+    },
     "aircrafts": {
       ".read": "auth !== null",
       ".write": "auth !== null && root.child('admins/' + auth.uid).exists()",

--- a/functions/associatedMovements/setAssociatedMovementsCronJob.js
+++ b/functions/associatedMovements/setAssociatedMovementsCronJob.js
@@ -2,8 +2,12 @@ const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const utils = require('./utils')
 
-// Run once a week at midnight, set missing associated movements
+// Migration job to set missing associated movements.
 // Manually run the task here https://console.cloud.google.com/cloudscheduler
+//
+// The job is scheduled nightly if `maintenance.setAssociatedMovementsCronJobEnabled` is set to true in the database.
+// However, in general it should be disabled after the migration has been executed successfully once (for cost reasons)
+
 const handleImmatriculation = async (immatriculation, movements) => {
   const aircraftMovements = await utils.loadAircraftMovements(immatriculation)
   const homeBase = await utils.isHomeBase(immatriculation)
@@ -21,16 +25,55 @@ const handleImmatriculation = async (immatriculation, movements) => {
   functions.logger.log(`Done setting associated movements for ${aircraftMovementsWithoutAssociation.length} movements of immatriculation ${immatriculation}`)
 }
 
-const loadWithoutAssociation = path => admin.database()
-  .ref(path)
-  .orderByChild("associatedMovement")
-  .equalTo(null)
-  .once("value")
+const loadWithoutAssociation = async path => {
+  const allMovements = await admin.database()
+    .ref(path)
+    .once("value")
 
-exports.setAssociatedMovementsCronJob = functions.pubsub
-  .schedule('0 15 * * 0') // midnight from sunday to monday in Europe (in pacific time)
+  functions.logger.log(`Total ${allMovements.numChildren()} movements found`)
+
+  const associations = await admin.database()
+    .ref('/movementAssociations' + path)
+    .once("value")
+
+  functions.logger.log(`Total ${associations.numChildren()} associations found`)
+
+  const presentKeys = new Set()
+
+  associations.forEach(snapshot => {
+    presentKeys.add(snapshot.ref.key)
+  })
+
+  const movementsWithoutAssociation = []
+
+  allMovements.forEach(snapshot => {
+    if (!presentKeys.has(snapshot.ref.key)) {
+      movementsWithoutAssociation.push(snapshot)
+    }
+  })
+
+  functions.logger.log(`Total ${movementsWithoutAssociation.length} movements without association found`)
+
+  return movementsWithoutAssociation
+}
+
+exports.setAssociatedMovementsCronJob = functions
+  .runWith({
+    timeoutSeconds: 540, // default of 1min not enough for big collections
+    memory: '512MB' // default of 256MB not enough for big collections
+  })
+  .pubsub
+  .schedule('0 15 * * 0') // midnight on sunday in Europe (in pacific time)
   .onRun(async () => {
     functions.logger.log('Starting job')
+
+    const enabled = await admin.database()
+      .ref('/settings/setAssociatedMovementsCronJobEnabled')
+      .once("value")
+    if (enabled.val() !== true) {
+      functions.logger.log('Job is not enabled. Aborting...')
+      return
+    }
 
     const loadedMovements = await Promise.all([
       loadWithoutAssociation('/departures'),

--- a/functions/associatedMovements/utils.js
+++ b/functions/associatedMovements/utils.js
@@ -107,21 +107,19 @@ const getAssociatedMovement = (movement, isHomeBase, aircraftMovements) => {
   throw new Error('Code should not be reached')
 }
 
-const path = (movementType) => movementType === 'departure' ? '/departures' : '/arrivals'
+const path = (movementType) => '/movementAssociations' + (movementType === 'departure' ? '/departures' : '/arrivals')
 
 const setAssociatedMovement = async (movementKey, movementType, associatedMovement) => {
   const newData = associatedMovement ? {
-    associatedMovement: {
-      key: associatedMovement.key,
-      type: associatedMovement.type
-    }
+    key: associatedMovement.key,
+    type: associatedMovement.type
   } : {
-    associatedMovement: {
-      type: 'none'
-    }
+    type: 'none'
   }
 
-  await admin.database().ref(path(movementType)).child(movementKey).update(newData)
+  const basePath = path(movementType)
+
+  await admin.database().ref(basePath).child(movementKey).update(newData)
 }
 
 const isHomeBase = async immatriculation => {

--- a/src/components/MovementList/MovementHeader.js
+++ b/src/components/MovementList/MovementHeader.js
@@ -5,7 +5,7 @@ import dates from '../../util/dates';
 import Action from './Action';
 import MaterialIcon from '../MaterialIcon';
 import HomeBaseIcon from './HomeBaseIcon';
-import {TYPE_LABELS, ACTION_LABELS} from './labels';
+import {ACTION_LABELS, TYPE_LABELS} from './labels';
 
 const ICON_HEIGHT = 30;
 
@@ -166,9 +166,9 @@ class MovementHeader extends React.PureComponent {
               onClick={this.handleActionClick}
               responsive
             />
-          ) : !props.data.associatedMovement
-            ? <MaterialIcon icon="sync" rotate="left"/>
-            : null
+          ) : props.data.associatedMovement === null
+            ? <MaterialIcon icon="sync" rotate="left"/> // show rotating icon if `associatedMovement` is null (= state where the associated movement is being monitored, but not set yet)
+            : null // if `associatedMovement` is undefined, we don't want to show anything (= state before the associated movement is even being monitored)
           }
         </ActionColumn>
         <ActionColumn className="delete" alignMiddle>

--- a/src/containers/MovementListContainer.js
+++ b/src/containers/MovementListContainer.js
@@ -12,17 +12,16 @@ import {loadAircraftSettings} from '../modules/settings/aircrafts'
 import MovementList from '../components/MovementList';
 import ImmutableItemsArray from '../util/ImmutableItemsArray';
 
-/**
- * Sometimes there's a bug which results in empty departures/arrivals with just
- * `associatedMovement: {type: 'none' }`.
- *
- * Couldn't find out what the reason for this yet. But by filtering them out here
- * we make sure that the movement list can still be used (otherwise there are null
- * pointers, because all the required fields are missing on the movement).
- */
 const getMovementsFromState = state => new ImmutableItemsArray(
   state.movements.data.array
-    .filter(movement => !!movement.location)
+    .map(movement => ({
+      ...movement,
+      associatedMovement: state
+        .movements
+        .associatedMovements
+        [movement.type === 'departure' ? 'departures' : 'arrivals']
+        [movement.key]
+    }))
 )
 
 const getMovements = state => {

--- a/src/modules/movements/actions.js
+++ b/src/modules/movements/actions.js
@@ -18,6 +18,8 @@ export const EDIT_MOVEMENT = 'EDIT_MOVEMENT';
 export const START_INITIALIZE_WIZARD = 'START_INITIALIZE_WIZARD';
 export const WIZARD_INITIALIZED = 'WIZARD_INITIALIZED';
 export const SET_MOVEMENTS_FILTER = 'SET_MOVEMENTS_FILTER';
+export const SET_ASSOCIATED_MOVEMENT = 'SET_ASSOCIATED_MOVEMENT';
+export const CLEAR_ASSOCIATED_MOVEMENTS = 'CLEAR_ASSOCIATED_MOVEMENTS';
 
 export function loadMovements(clear) {
   return {
@@ -188,5 +190,22 @@ export function setMovementsFilter(filter) {
     payload: {
       filter
     }
+  };
+}
+
+export function setAssociatedMovement(movementType, movementKey, associatedMovement) {
+  return {
+    type: SET_ASSOCIATED_MOVEMENT,
+    payload: {
+      movementType,
+      movementKey,
+      associatedMovement
+    }
+  };
+}
+
+export function clearAssociatedMovements() {
+  return {
+    type: CLEAR_ASSOCIATED_MOVEMENTS
   };
 }

--- a/src/modules/movements/reducer.js
+++ b/src/modules/movements/reducer.js
@@ -35,9 +35,25 @@ export const addMovementByKey = (state, action) => ({
   }
 });
 
-export const clearMovementsByKey = (state, action) => ({
+export const clearMovementsByKey = (state) => ({
   ...state,
   byKey: {}
+});
+
+export const clearAssociatedMovements = (state) => ({
+  ...state,
+  associatedMovements: INITIAL_STATE.associatedMovements
+});
+
+export const setAssociatedMovement = (state, action) => ({
+  ...state,
+  associatedMovements: {
+    ...state.associatedMovements,
+    [action.payload.movementType === 'departure' ? 'departures' : 'arrivals']: {
+      ...state.associatedMovements[action.payload.movementType === 'departure' ? 'departures' : 'arrivals'],
+      [action.payload.movementKey]: action.payload.associatedMovement
+    }
+  }
 });
 
 const ACTION_HANDLERS = {
@@ -47,10 +63,16 @@ const ACTION_HANDLERS = {
   [actions.SET_MOVEMENTS_FILTER]: setFilter,
   [actions.ADD_MOVEMENT_BY_KEY]: addMovementByKey,
   [actions.CLEAR_MOVEMENTS_BY_KEY]: clearMovementsByKey,
+  [actions.SET_ASSOCIATED_MOVEMENT]: setAssociatedMovement,
+  [actions.CLEAR_ASSOCIATED_MOVEMENTS]: clearAssociatedMovements,
 };
 
 const INITIAL_STATE = {
   data: new ImmutableItemsArray(),
+  associatedMovements: {
+    departures: {},
+    arrivals: {}
+  },
   loading: false,
   loadingFailed: false,
   byKey: {},

--- a/src/modules/movements/remote.js
+++ b/src/modules/movements/remote.js
@@ -48,3 +48,17 @@ export function saveMovement(path, key, movement) {
     }
   });
 }
+
+export function addMovementAssociationListener(movementType, movementKey, callback) {
+  const ref = firebase('/movementAssociations')
+    .child(movementType === 'departure' ? 'departures' : 'arrivals')
+    .child(movementKey)
+  ref.on('value', callback);
+}
+
+export function removeMovementAssociationListener(movementType, movementKey) {
+  const ref = firebase('/movementAssociations')
+    .child(movementType === 'departure' ? 'departures' : 'arrivals')
+    .child(movementKey)
+  ref.off('value');
+}

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -1,12 +1,13 @@
-import { getPagination } from './pagination';
-import { takeEvery, takeLatest } from 'redux-saga'
-import { put, call, select, fork } from 'redux-saga/effects'
-import { initialize, destroy, getFormValues } from 'redux-form'
-import createChannel, { monitor } from '../../util/createChannel';
+import {getPagination} from './pagination';
+import {takeEvery, takeLatest} from 'redux-saga'
+import {call, fork, put, select} from 'redux-saga/effects'
+import {destroy, getFormValues, initialize} from 'redux-form'
+import createChannel, {monitor} from '../../util/createChannel';
 import * as actions from './actions';
 import * as remote from './remote';
-import {localToFirebase, firebaseToLocal, transferValues, compareDescending} from '../../util/movements';
-import { error } from '../../util/log';
+import {addMovementAssociationListener, removeMovementAssociationListener} from './remote';
+import {compareDescending, firebaseToLocal, localToFirebase, transferValues} from '../../util/movements';
+import {error} from '../../util/log';
 import dates from '../../util/dates';
 import ImmutableItemsArray from '../../util/ImmutableItemsArray';
 
@@ -130,6 +131,7 @@ export function* loadMovements(channel, action) {
 
       if (clear) {
         yield put(actions.clearMovementsByKey())
+        yield put(actions.clearAssociatedMovements())
       }
     }
   } catch(e) {
@@ -211,7 +213,25 @@ export function* addMovements(departuresSnapshot, arrivalsSnapshot, existingMove
 
   const newData = existingMovements.insertAll(movements, compareDescending);
 
+  yield call(monitorAssociations, newData, existingMovements, channel)
+
   channel.put(actions.setMovements(newData));
+}
+
+export function* monitorAssociations(newMovements, oldMovements, channel) {
+  newMovements.array
+    .filter(movement => !oldMovements.containsKey(movement.key))
+    .forEach(movement => monitorAssociation(movement, channel))
+
+  oldMovements.array
+    .filter(movement => !newMovements.containsKey(movement.key))
+    .forEach(movement => removeMovementAssociationListener(movement.type, movement.key))
+}
+
+export function monitorAssociation(movement, channel) {
+  addMovementAssociationListener(movement.type, movement.key, (snapshot) => {
+    channel.put(actions.setAssociatedMovement(movement.type, movement.key, snapshot.val()));
+  })
 }
 
 export function* monitorRef(ref, channel, movementType, eventActions) {
@@ -265,6 +285,8 @@ export function* addMovementToState(snapshot, movementType, currentState, channe
       return;
     }
 
+    yield call(monitorAssociation, movement, channel)
+
     channel.put(actions.setMovements(newData));
   }
 }
@@ -272,9 +294,13 @@ export function* addMovementToState(snapshot, movementType, currentState, channe
 export function* removeMovementFromState(snapshot, channel) {
   const {data} = yield select(stateSelector);
 
+  const movement = data.getByKey(snapshot.key)
+
   const newState = {
     data: data.remove(snapshot.key)
   };
+
+  yield call(removeMovementAssociationListener, movement.type, movement.key)
 
   channel.put(actions.setMovements(newState.data));
 

--- a/src/util/ImmutableItemsArray.js
+++ b/src/util/ImmutableItemsArray.js
@@ -26,6 +26,10 @@ class ImmutableItemsArray {
     }
   }
 
+  containsKey(key) {
+    return !!this.getByKey(key)
+  }
+
   getByKey(key) {
     const index = this.keys[key];
     if (typeof index === 'number') {


### PR DESCRIPTION
- The associations are now tracked at `/movementAssociations` (there's a sublist `departures` resp `arrivals`)
- There was a bug where the whole movement data was cleared when the `associatedMovement` property was set (even though `update()` was used to set the `associatedMovement` property, which shouldn't touch all the other existing properties). To prevent this, we moved this property to the completely separate collection and don't touch the movement records anymore for mapping the departure and arrival records.
- To migrate data in existing databases, the cron job `setAssociatedMovementsCronJob` can be used. We don't have to wait for it to get triggered by the schedule, but can trigger it manually here: https://console.cloud.google.com/cloudscheduler.
- The boolean property `/settings/setAssociatedMovementsCronJobEnabled` has to be set to true in order for the cron job to actually do something. If the property is not `true`, the cron job aborts the execution. We shouldn't run the job too often, because querying a lot of documents a lot of times is expensive (money-wise).