### PR TITLE
Try to fix deployment of firebase rules (#2)

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -29,7 +29,8 @@ jobs:
           project_id: ${{ vars.FIREBASE_PROJECT }}
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
-      - run: firebase deploy --only hosting,database
+      - run: firebase target:apply database main ${{ vars.FIREBASE_PROJECT }}
+      - run: firebase deploy --only hosting,database:main
   build_and_deploy_functions:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ Before executing this command, make sure the correct project was built using the
 mentioned at the beginning of this document.
 
 ```
-$ firebase deploy --only hosting,database
+$ firebase target:apply database main {RTDB NAME}
+$ firebase deploy --only hosting,database:main
 ```
+
+(e.g. `lszt-test` for `{RTDB NAME}`)
 
 ##### Deploy cloud functions
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,8 @@
 {
-  "database": {
+  "database": [{
+    "target": "main",
     "rules": "build/firebase-rules.json"
-  },
+  }],
   "hosting": {
     "public": "build",
     "rewrites": [{


### PR DESCRIPTION
- The issue wasn't that the firebase rules were ignored (see previous commit), but that the rules got deployed to the default rtdb (if there is one) instead of the one we're actually using
- To fix this, we have to specify the database instance to deploy the rules to using firebase targets. So, before deploying the database rules, we have to set the target now like this: `firebase target:apply database main {RTDB NAME}` (e.g. `firebase target:apply database main lszt-test`) After this, the target `main` has to be specified in the deploy command like this: `firebase deploy --only database:main`