### PR TITLE
Add payment method `twint_external`

### DIFF
--- a/projects/default.json
+++ b/projects/default.json
@@ -10,5 +10,6 @@
     "Die verfügbare Pistenlänge ist ausreichend.",
     "Bei Passagierflügen: Ich habe in den letzten 90 Tagen mindestens 3 Landungen absolviert.",
     "Der Preflight-Check wurde ausgeführt."
-  ]
+  ],
+  "paymentMethods": ["cash"]
 }

--- a/projects/lszm.json
+++ b/projects/lszm.json
@@ -83,5 +83,5 @@
   },
   "theme": "lszm",
   "title": "Flightbox - Flugplatz Mollis",
-  "cardPaymentsEnabled": false
+  "paymentMethods": ["cash", "twint_external"]
 }

--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -102,5 +102,5 @@
   "flightnetCompany": "mfgt",
   "theme": "lszt",
   "title": "MFGT Bewegungen",
-  "cardPaymentsEnabled": true
+  "paymentMethods": ["cash", "card"]
 }

--- a/src/components/wizards/ArrivalWizard/Finish/Finish.js
+++ b/src/components/wizards/ArrivalWizard/Finish/Finish.js
@@ -8,11 +8,14 @@ import Message, {ReferenceNumberMessage} from './Message';
 import CashPaymentMessage from './CashPaymentMessage'
 import FinishActions from './FinishActions'
 import PaymentMethod from '../../../../containers/PaymentMethodContainer'
+import objectToArray from '../../../../util/objectToArray'
 
 const getHeading = isUpdate =>
   isUpdate === true
     ? 'Die Ankunft wurde erfolgreich aktualisiert!'
     : 'Ihre Ankunft wurde erfolgreich erfasst!';
+
+const enabledPaymentMethods = objectToArray(__CONF__.paymentMethods);
 
 const Finish = props => {
   const {
@@ -49,7 +52,7 @@ const Finish = props => {
         </>
       )}
       {isHomeBase === false ? (
-        __CARD_PAYMENTS_ENABLED__ ? (
+        enabledPaymentMethods.length > 1 ? (
           <PaymentMethod
             itemKey={itemKey}
             email={email}
@@ -65,6 +68,7 @@ const Finish = props => {
             goAroundFeeSingle={goAroundFeeSingle}
             goAroundFeeCode={goAroundFeeCode}
             goAroundFeeTotal={goAroundFeeTotal}
+            enabledPaymentMethods={enabledPaymentMethods}
           />
         ) : (
           <>

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
@@ -6,6 +6,7 @@ import SingleSelect from '../../../SingleSelect'
 import {CancelButton, NextButton} from '../../../WizardNavigation'
 import CashPaymentMessage from './CashPaymentMessage'
 import FinishActions from './FinishActions'
+import TwintPaymentMessage from './TwintPaymentMessage'
 
 const PAYMENT_METHODS = [{
     label: 'Karte',
@@ -21,6 +22,10 @@ const PAYMENT_METHODS = [{
   {
     label: 'Bar',
     value: 'cash'
+  },
+  {
+    label: 'Twint',
+    value: 'twint_external'
   }]
 
 const Container = styled.div`
@@ -74,7 +79,8 @@ const PaymentMethod = ({
                          finish,
                          setMethod,
                          setStep,
-                         cancelCardPayment
+                         cancelCardPayment,
+                         enabledPaymentMethods
                        }) => (
   <Container>
     {failure && (
@@ -84,6 +90,8 @@ const PaymentMethod = ({
       <>
         {method === 'cash' ? (
           <CashPaymentMessage itemKey={itemKey}/>
+        ) : method === 'twint_external' ? (
+          <TwintPaymentMessage itemKey={itemKey}/>
         ) : (
           <InstructionMessage>Die Zahlung war erfolgreich</InstructionMessage>
         )}
@@ -121,7 +129,7 @@ const PaymentMethod = ({
         <InstructionMessage>Bitte wählen Sie eine Zahlungsart:</InstructionMessage>
         <SelectContainer>
           <SingleSelect
-            items={PAYMENT_METHODS}
+            items={PAYMENT_METHODS.filter(method => enabledPaymentMethods.includes(method.value))}
             orientation="vertical"
             onChange={e => setMethod(e.target.value)}
             value={method}
@@ -136,7 +144,7 @@ const PaymentMethod = ({
               return
             }
 
-            if (method === 'cash') {
+            if (method === 'cash' || method === 'twint_external') {
               setStep(Step.COMPLETED)
             } else if (method === 'card') {
               setStep(Step.CONFIRMED)
@@ -206,6 +214,7 @@ PaymentMethod.propTypes = {
   setMethod: PropTypes.func.isRequired,
   setStep: PropTypes.func.isRequired,
   cancelCardPayment: PropTypes.func.isRequired,
+  enabledPaymentMethods: PropTypes.arrayOf(PropTypes.string).isRequired
 }
 
 export default PaymentMethod

--- a/src/components/wizards/ArrivalWizard/Finish/TwintPaymentMessage.js
+++ b/src/components/wizards/ArrivalWizard/Finish/TwintPaymentMessage.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {getFromItemKey} from '../../../../util/reference-number'
+import Message from './Message'
+
+const TwintPaymentMessage = ({itemKey}) => (
+  <Message>
+    Bitte überweisen Sie die fällige Landetaxe über den ausliegenden TWINT QR-Code und geben Sie die Referenznummer {getFromItemKey(itemKey)} als Zahlungszweck an.
+  </Message>
+)
+
+TwintPaymentMessage.propTypes = {
+  itemKey: PropTypes.string.isRequired
+}
+export default TwintPaymentMessage

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,7 @@ const globals = {
   __DISABLE_IP_AUTHENTICATION__: env.disableIpAuthentication === true,
   __FLIGHTNET_COMPANY__: JSON.stringify(projectConf.flightnetCompany),
   __LANDING_FEES__: JSON.stringify(projectConf.aerodrome.landingFees),
-  __GO_AROUND_FEES__: JSON.stringify(projectConf.aerodrome.goAroundFees),
-  __CARD_PAYMENTS_ENABLED__: projectConf.cardPaymentsEnabled === true
+  __GO_AROUND_FEES__: JSON.stringify(projectConf.aerodrome.goAroundFees)
 };
 
 module.exports = {


### PR DESCRIPTION
Similar to the cash payment method: we just display instructions on how to pay using TWINT (namely by scanning the QR code sticker)