### PR TITLE
Add env var FIREBASE_RTDB_NAME for deployment workflows

### DIFF
--- a/.github/workflows/firebase-hosting-dev.yml
+++ b/.github/workflows/firebase-hosting-dev.yml
@@ -29,7 +29,7 @@ jobs:
           project_id: ${{ vars.FIREBASE_PROJECT }}
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
-      - run: firebase target:apply database main ${{ vars.FIREBASE_PROJECT }}
+      - run: firebase target:apply database main ${{ vars.FIREBASE_RTDB_NAME }}
       - run: firebase deploy --only hosting,database:main
   build_and_deploy_functions:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-hosting-prod.yml
+++ b/.github/workflows/firebase-hosting-prod.yml
@@ -27,7 +27,7 @@ jobs:
           project_id: ${{ vars.FIREBASE_PROJECT }}
           tools-version: 13
           firebase_token: ${{ secrets.FIREBASE_TOKEN }}
-      - run: firebase target:apply database main ${{ vars.FIREBASE_PROJECT }}
+      - run: firebase target:apply database main ${{ vars.FIREBASE_RTDB_NAME }}
       - run: firebase deploy --only hosting,database:main
   build_and_deploy_functions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
FIREBASE_PROJECT and realtime database name not identical for LSZT prod. Therefore, we need an additional variable.