### PR TITLE
Don't (try) relogin with email after logout if query param still present

### DIFF
--- a/src/util/firebase.js
+++ b/src/util/firebase.js
@@ -74,6 +74,10 @@ export function authenticateEmail(email) {
 }
 
 export function isSignInWithEmail() {
+  const email = window.localStorage.getItem('emailForSignIn');
+  if (!email) {
+    return false
+  }
   return Firebase.auth().isSignInWithEmailLink(window.location.href)
 }
 


### PR DESCRIPTION
After we log out after having been logged in with email, the query params for the email login could still be present from the previous login and `Firebase.auth().isSignInWithEmailLink(window.location.href)` could return true.

However, we don't want to try to relogin again in
this case and as the query params are likely to be expired, this also wouldn't even work.

Therefore, we check if the `emailForSignIn` is present in the local storage here to detect if we're actually in the process of logging in (the item is removed from the local storage after the successful login, so if it's not present, we're not in the process of logging in)