### PR TITLE
Add `local` flag to auth data if user has logged in on site

### DIFF
--- a/src/components/LoginPage/EmailLoginForm.js
+++ b/src/components/LoginPage/EmailLoginForm.js
@@ -6,9 +6,9 @@ import Failure from './Failure';
 import Button from '../Button';
 import GuestTokenLogin from '../../containers/GuestTokenLoginContainer'
 
-const handleSubmit = (authenticate, email, e) => {
+const handleSubmit = (authenticate, email, local, e) => {
   e.preventDefault();
-  authenticate(email);
+  authenticate(email, local);
 };
 
 const StyledLabeledComponent = styled(LabeledComponent)`
@@ -88,7 +88,7 @@ const EmailLoginForm = props => {
   return (
     <div>
         <StyledForm
-          onSubmit={handleSubmit.bind(null, authenticate, email)}
+          onSubmit={handleSubmit.bind(null, authenticate, email, !!queryToken)}
           disabled={props.submitting}
           data-cy="login-form"
         >

--- a/src/modules/auth/actions.js
+++ b/src/modules/auth/actions.js
@@ -65,11 +65,12 @@ export function guestTokenAuthenticationFailure() {
   };
 }
 
-export function sendAuthenticationEmail(email) {
+export function sendAuthenticationEmail(email, local) {
   return {
     type: SEND_AUTHENTICATION_EMAIL,
     payload: {
-      email
+      email,
+      local
     },
   };
 }
@@ -98,12 +99,13 @@ export function usernamePasswordAuthenticationFailure() {
   };
 }
 
-export function requestFirebaseAuthentication(token, failureAction) {
+export function requestFirebaseAuthentication(token, failureAction, local) {
   return {
     type: REQUEST_FIREBASE_AUTHENTICATION,
     payload: {
       token,
-      failureAction
+      failureAction,
+      local
     },
   };
 }

--- a/src/modules/auth/sagas.js
+++ b/src/modules/auth/sagas.js
@@ -94,9 +94,9 @@ export function* doUsernamePasswordAuthentication(action) {
 export function* sendAuthenticationEmail(action) {
   try {
     yield put(actions.setSubmitting());
-    const { email } = action.payload;
+    const { email, local } = action.payload;
     if (isNotEmptyString(email)) {
-      yield call(fbAuthEmail, email);
+      yield call(fbAuthEmail, email, local);
       yield put(actions.sendAuthenticationEmailSuccess());
     }
   } catch(e) {
@@ -159,12 +159,15 @@ export function* doListenFirebaseAuthentication(action) {
       }
     } else {
       const loginData = yield call(getLoginData, uid)
+      const guest = uid === 'guest'
+      const local = guest || window.localStorage.getItem('isLocalSignIn') === 'true'
       authData = {
         uid,
         expiration: expires * 1000,
         token,
         admin: loginData && loginData.admin === true,
-        guest: uid === 'guest',
+        guest,
+        local,
         links: !loginData || loginData.links !== false,
         name: yield call(getName, uid),
         email

--- a/src/util/firebase.js
+++ b/src/util/firebase.js
@@ -56,7 +56,7 @@ export function authenticate(token) {
   });
 }
 
-export function authenticateEmail(email) {
+export function authenticateEmail(email, local) {
   return new Promise((resolve, reject) => {
     initialize();
     Firebase.auth().sendSignInLinkToEmail(email, {
@@ -65,6 +65,7 @@ export function authenticateEmail(email) {
     })
       .then(() => {
         window.localStorage.setItem('emailForSignIn', email);
+        window.localStorage.setItem('isLocalSignIn', local);
         resolve();
       })
       .catch(error => {


### PR DESCRIPTION
This is the case, if the user came to the Flightbox by scanning a QR code which opens the Flightbox URL with a query token which also allows to sign in as guest.

The `local` flag is true if the `uid` is `guest` (which can only be the case if they came from a QR code link) or if the email login was executed with a query token being present.