### PR TITLE
Do not show options in AD/aircraft/user dropdown immediately on focus

### DIFF
--- a/src/components/AerodromeDropdown/AerodromeDropdown.js
+++ b/src/components/AerodromeDropdown/AerodromeDropdown.js
@@ -54,6 +54,7 @@ const AerodromeDropdown = props => (
     onChange={callWithValue.bind(null, props.onChange, props.aerodromes.data.array)}
     onBeforeInputChange={normalize}
     value={props.value}
+    showOptionsOnFocus={false}
     noOptionsText="Kein Flugplatz gefunden"
     moreOptionsText="Mehr Flugplätze vorhanden! Tippen Sie einen Teil des ICAO-Codes oder des Namens, um die Liste einzuschränken."
     onFocus={props.onFocus}

--- a/src/components/AircraftDropdown/AircraftDropdown.js
+++ b/src/components/AircraftDropdown/AircraftDropdown.js
@@ -47,6 +47,7 @@ const AircraftDropdown = props => (
     onChange={callWithValue.bind(null, props.onChange, props.aircrafts.data.array)}
     onBeforeInputChange={normalizeImmatriculation}
     value={props.value}
+    showOptionsOnFocus={false}
     noOptionsText="Kein Flugzeug gefunden"
     moreOptionsText="Mehr Flugzeuge vorhanden! Tippen Sie einen Teil der Immatrikulation, um die Liste einzuschränken."
     onFocus={props.onFocus}

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -26,7 +26,6 @@ class Dropdown extends Component {
       filter: '',
       focusedOption: null,
       inputFocused: false,
-      optionsVisible: false,
     };
     this.options = [];
     this.handleContainerKeyDown = this.handleContainerKeyDown.bind(this);
@@ -97,21 +96,20 @@ class Dropdown extends Component {
   }
 
   renderOptions() {
-    if (this.state.optionsVisible !== true) {
+    if (this.state.filter.length === 0 && (!this.state.inputFocused || !this.props.showOptionsOnFocus)) {
       return null;
     }
 
     const filteredOptions = this.getFilteredOptions(this.state.filter);
 
-    let options;
+    if (filteredOptions.length === 0) {
+      return null
+    }
 
-    if (filteredOptions.length > 0) {
-      options = filteredOptions.slice(0, this.props.optionsRenderLimit).map(option => this.renderOption(option));
-      if (filteredOptions.length > this.props.optionsRenderLimit) {
-        options.push(this.renderMoreOptionsLabel());
-      }
-    } else {
-      options = this.renderNoOptionsLabel();
+    const options = filteredOptions.slice(0, this.props.optionsRenderLimit).map(option => this.renderOption(option));
+
+    if (filteredOptions.length > this.props.optionsRenderLimit) {
+      options.push(this.renderMoreOptionsLabel());
     }
 
     return (
@@ -190,7 +188,6 @@ class Dropdown extends Component {
     }
     this.setState({
       inputFocused: true,
-      optionsVisible: true,
       filter: '',
     });
     this.setFocusedOption(this.getInitiallyFocusedOption());
@@ -202,7 +199,6 @@ class Dropdown extends Component {
   handleInputBlur() {
     this.setState({
       inputFocused: false,
-      optionsVisible: false,
     });
     if (this.state.filter && this.props.mustSelect !== true) {
       this.setValue(this.state.filter);
@@ -234,7 +230,7 @@ class Dropdown extends Component {
       return;
     }
 
-    if (e.which === KEY_CODE_ARROW_DOWN && this.state.optionsVisible === false) {
+    if (e.which === KEY_CODE_ARROW_DOWN) {
       this.input.focus();
       return;
     }
@@ -351,6 +347,7 @@ Dropdown.propTypes = {
   optionRenderer: PropTypes.func.isRequired,
   valueRenderer: PropTypes.func,
   optionFilter: PropTypes.func,
+  showOptionsOnFocus: PropTypes.bool,
   noOptionsText: PropTypes.string,
   moreOptionsText: PropTypes.string,
   mustSelect: PropTypes.bool,
@@ -365,6 +362,7 @@ Dropdown.propTypes = {
 };
 
 Dropdown.defaultProps = {
+  showOptionsOnFocus: true,
   noOptionsText: 'No options found',
   moreOptionsText: 'Too many options available. Type to filter...',
   mustSelect: false,

--- a/src/components/UserDropdown/UserDropdown.js
+++ b/src/components/UserDropdown/UserDropdown.js
@@ -44,6 +44,7 @@ const UserDropdown = props => (
     optionRenderer={optionRenderer(props.users.data.array)}
     onChange={callWithValue.bind(null, props.onChange, props.users.data.array)}
     value={props.value}
+    showOptionsOnFocus={false}
     noOptionsText="Kein Mitglied gefunden"
     moreOptionsText="Mehr Mitglieder vorhanden! Tippen Sie einen Teil der Mitgliedernummer, um die Liste einzuschränken."
     onFocus={props.onFocus}


### PR DESCRIPTION
- Before, the options were shown as soon as the dropdown field was focused - now it's only visible after starting to type
- Before, a "no options" item was shown if nothing was found - now we just don't show anything at all
- Reason: the members dropdown will never show any options for most aerodromes where the Flightbox is running. Also, it makes more sense to wait for the user to start typing so that they only see the matching results anyway and don't present them an overwhelming list before they even started typing for these lists