### PR TITLE
Fix endless loading of new dep/arrival wizard with IP auth

### DIFF
--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -23,7 +23,7 @@ export const authSelector = state => state.auth.data
 export function* getProfileDefaultValues() {
   const auth = yield select(authSelector)
 
-  if (!auth || auth.guest === true || auth.uid === 'ipauth') {
+  if (!auth || !auth.uid || auth.guest === true) {
     return {}
   }
 


### PR DESCRIPTION
With IP auth, the `auth.uid` is `undefined`, not `ipauth`. Therefore, `getProfileDefaultValues()` tried to load the default values which it didn't have permission for.

This is fixed now (not trying to load the profile default values with IP auth anymore)