### PR TITLE
Fix manual selection of an aircraft type option

### DIFF
--- a/src/components/wizards/pages/AircraftPage.js
+++ b/src/components/wizards/pages/AircraftPage.js
@@ -87,7 +87,7 @@ const AircraftPage = (props) => {
             updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount)
             updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount)
 
-            return mtow
+            return aircraftCategory
           }}
         />
       </FieldSet>


### PR DESCRIPTION
If we return the MTOW vlaue instead of the aircraft category, the MTOW will be set in the `aircraftCategory` form value, which leads to a null pointer, because there is no dropdown option with this value.