### PR TITLE
Set login form for LSZT to "email" (before "usernamePassword")

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -102,5 +102,6 @@
   "flightnetCompany": "mfgt",
   "theme": "lszt",
   "title": "MFGT Bewegungen",
-  "paymentMethods": ["cash", "card"]
+  "paymentMethods": ["cash", "card"],
+  "loginForm": "email"
 }


### PR DESCRIPTION
- This allows us to not use Flightmore anymore for authentication
- Be careful to only release this once the prod setup is ready (otherwise remove this again before releasing something to prod, there's no separate feature toggle for dev and prod)