### PR TITLE
Reset login form for LSZT to "usernamePassword" (before "email")

### DIFF
--- a/projects/lszt.json
+++ b/projects/lszt.json
@@ -102,6 +102,5 @@
   "flightnetCompany": "mfgt",
   "theme": "lszt",
   "title": "MFGT Bewegungen",
-  "paymentMethods": ["cash", "card"],
-  "loginForm": "email"
+  "paymentMethods": ["cash", "card"]
 }


### PR DESCRIPTION
- Was set to "email" in commit 4b7c9bb3bc378c0c3e6173965b93037d9140183b, but not ready for prod yet (don't know yet when this will be the case)
- Therefore, resetting it for now to not release it to prod by accident (we can't enable it only for the dev/test system and not on prod)