### PR TITLE
Fix performance issue when filtering for aircraft immatriculation

### DIFF
--- a/src/modules/movements/reducer.js
+++ b/src/modules/movements/reducer.js
@@ -24,6 +24,7 @@ export function setLoadingFailure(state) {
 
 export const setFilter = (state, action) => ({
   ...state,
+  previousFilter: state.filter,
   filter: action.payload.filter
 })
 
@@ -83,7 +84,8 @@ const INITIAL_STATE = {
     },
     immatriculation: '',
     onlyWithoutAssociatedMovement: false
-  }
+  },
+  previousFilter: null
 };
 
 const reducer = (initialState, actionHandlers) => {

--- a/src/modules/movements/sagas.js
+++ b/src/modules/movements/sagas.js
@@ -123,8 +123,21 @@ export function getOldest(snapshot) {
   return oldest;
 }
 
+function hasFilterDateChanged(newFilter, previousFilter) {
+  const newStart = newFilter.date.start
+  const newEnd = newFilter.date.end
+
+  const previousStart = previousFilter.date.start
+  const previousEnd = previousFilter.date.end
+
+  return newStart !== previousStart || newEnd !== previousEnd;
+}
+
 export function* filterMovements() {
-  yield put(actions.loadMovements(true));
+  const {filter, previousFilter} = yield select(stateSelector);
+  if (hasFilterDateChanged(filter, previousFilter)) {
+    yield put(actions.loadMovements(true));
+  }
 }
 
 export function* loadMovements(channel, action) {


### PR DESCRIPTION
- When typing immatriculations in the filter, the UI reacts very slowly and even freezes if there are a lot of movements
- This issue was raised by LSPV
- The reason for the problem was that the movements were reloaded from the firebase database on *every* change in the filter. The movements were also reloaded when the immatriculation or the `onlyWithoutAssociatedMovement`flag were being changed - these filters are only applied in the client though and we need to reload the movements only if the filter start or end date were changed.