### PR TITLE
Fix masking of email address with parts shorter than 3 characters

### DIFF
--- a/src/util/masking.js
+++ b/src/util/masking.js
@@ -29,5 +29,9 @@ export function maskText(text) {
     return text
   }
 
+  if (text.length < 3) {
+    return '*'.repeat(text.length)
+  }
+
   return text[0] + '*'.repeat(text.length - 2) + text.slice(-1)
 }


### PR DESCRIPTION
Fixes "RangeError: "Invalid count value" when calling String.repeat