### PR TITLE
Add "Guest only" login link param

### DIFF
--- a/src/components/LoginPage/EmailLoginForm.js
+++ b/src/components/LoginPage/EmailLoginForm.js
@@ -57,6 +57,7 @@ const StyledOrText = styled.span`
 const EmailLoginForm = props => {
   const {
     queryToken,
+    guestOnly,
     authenticate,
     email,
     submitting,
@@ -87,6 +88,7 @@ const EmailLoginForm = props => {
 
   return (
     <div>
+      {!guestOnly && (
         <StyledForm
           onSubmit={handleSubmit.bind(null, authenticate, email, !!queryToken)}
           disabled={props.submitting}
@@ -107,25 +109,32 @@ const EmailLoginForm = props => {
             <LoginDialogButton type="button" label="Abbrechen" onClick={props.onCancel} dataCy="cancel"/>
           )}
         </StyledForm>
-        {queryToken && (
-          <>
-            <StyledHint>Wenn Sie sich mit Ihrer E-Mail-Adresse anmelden, können Sie Ihre eigenen erfassten
-              Bewegungen
-              anschliessend noch einsehen und
-              ggf. korrigieren.
-            </StyledHint>
-            <StyledOrContainer><StyledOrText>oder</StyledOrText></StyledOrContainer>
-            <GuestTokenLogin queryToken={queryToken}/>
-            <StyledHint>Wenn Sie sich als Gast anmelden, können Sie nur Ihre Ankunft und Ihren Abflug erfassen. Die
-              erfassten Bewegungen können Sie anschliessend nicht mehr einsehen.
-            </StyledHint>
-          </>
-        )}
-      </div>
+      )}
+      {queryToken && (
+        guestOnly
+          ? <GuestTokenLogin queryToken={queryToken}/>
+          : (
+            <>
+              <StyledHint>Wenn Sie sich mit Ihrer E-Mail-Adresse anmelden, können Sie Ihre eigenen erfassten
+                Bewegungen
+                anschliessend noch einsehen und
+                ggf. korrigieren.
+              </StyledHint>
+              <StyledOrContainer><StyledOrText>oder</StyledOrText></StyledOrContainer>
+              <GuestTokenLogin queryToken={queryToken}/>
+              <StyledHint>Wenn Sie sich als Gast anmelden, können Sie nur Ihre Ankunft und Ihren Abflug erfassen. Die
+                erfassten Bewegungen können Sie anschliessend nicht mehr einsehen.
+              </StyledHint>
+            </>
+          )
+      )}
+    </div>
   )
 };
 
 EmailLoginForm.propTypes = {
+  queryToken: PropTypes.string,
+  guestOnly: PropTypes.bool,
   authenticate: PropTypes.func.isRequired,
   updateEmail: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,

--- a/src/components/LoginPage/LoginPage.js
+++ b/src/components/LoginPage/LoginPage.js
@@ -4,7 +4,7 @@ import EmailLoginForm from '../../containers/EmailLoginFormContainer'
 import UsernamePasswordLoginForm from '../../containers/UsernamePasswordLoginFormContainer'
 import styled from 'styled-components'
 import {withRouter} from 'react-router-dom'
-import getAuthQueryToken from '../../util/getAuthQueryToken'
+import getAuthQueryToken, {getGuestOnly} from '../../util/getAuthQueryToken'
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -45,12 +45,16 @@ const LoginInnerWrapper = styled.div`
 
 const LoginPage = ({location}) => {
   const queryToken = getAuthQueryToken(location)
+  const guestOnly = getGuestOnly(location)
   return (
     <StyledWrapper>
       <Header/>
       <LoginWrapper>
         <LoginInnerWrapper>
-      {__CONF__.loginForm === 'email' ? <EmailLoginForm queryToken={queryToken}/> : <UsernamePasswordLoginForm/>}
+          {__CONF__.loginForm === 'email'
+            ? <EmailLoginForm queryToken={queryToken} guestOnly={guestOnly}/>
+            : <UsernamePasswordLoginForm/>
+          }
         </LoginInnerWrapper>
       </LoginWrapper>
     </StyledWrapper>

--- a/src/util/getAuthQueryToken.js
+++ b/src/util/getAuthQueryToken.js
@@ -15,4 +15,15 @@ const getAuthQueryToken = location => {
   return null
 }
 
+export const getGuestOnly = location => {
+  if (location.state && location.state.guestOnly) {
+    return location.state.guestOnly
+  }
+
+  const query = new URLSearchParams(location.search)
+  const guestOnly = query.get('guestOnly')
+
+  return guestOnly === 'true'
+}
+
 export default getAuthQueryToken


### PR DESCRIPTION
- If the query param `guestOnly=true` is present for the guest login, we only show the guest login button and no email login form above it
- By default, the guest login link still also allows the email login (form on top of the guest login button)