### PR TITLE
Always show ldg fee in movement list if is defined

### DIFF
--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -115,7 +115,7 @@ class MovementDetails extends React.PureComponent {
               </DetailsBox>
             )
           }
-          {props.data.type === 'arrival' && props.isHomeBase === false && props.data.landingFeeTotal !== undefined && (
+          {props.data.type === 'arrival' && props.data.landingFeeTotal !== undefined && (
             <DetailsBox label="Gebühren">
               <MovementField label="Referenznummer" value={getFromItemKey(props.data.key)}/>
               <MovementField label="Landetaxe" value={getLandingFee(props.data)}/>


### PR DESCRIPTION
- We don't hide it anymore for homebase aircraft
- E.g. for lszm the home base pilots are also charged the landing fee, so it makes sense to display them
- We could also only show it if `__CONF__.homebasePayment` is enabled (like it is for lszm). However, the fees are due anyway also if `__CONF__.homebasePayment` is false - the pilots are just being charged in a different way. Therefore, there's no need to make it more complicated, we can just show it for everybody as long as they're defined