### PR TITLE
Fix hiding runway if helicopter for departures

### DIFF
--- a/src/containers/DepartureFlightPageContainer.js
+++ b/src/containers/DepartureFlightPageContainer.js
@@ -18,7 +18,7 @@ const filter = (items, values) => items.filter(item => !item.available || item.a
 
 const getHiddenFields = values => {
   const hiddenFields = []
-  if (isHelicopter(values.immatriculation, values.aircraftCategory)) {
+  if (__CONF__.aerodrome.noRunwayIfHelicopter === true && isHelicopter(values.immatriculation, values.aircraftCategory)) {
     hiddenFields.push('runway')
   }
   return hiddenFields


### PR DESCRIPTION
- The runway field should only be hidden if the config property `noRunwayIfHelicopter` is set to true
- This is already implemented like this in the arrival wizard (only departure wizard was wrong)