### PR TITLE
Save and show VAT of landing fees separately

### DIFF
--- a/firebase-rules-template.json
+++ b/firebase-rules-template.json
@@ -136,6 +136,18 @@
         "landingFeeTotal": {
           ".validate": "newData.isNumber() && newData.val() >= 0"
         },
+        "feeTotalNet": {
+          ".validate": "newData.isNumber()"
+        },
+        "feeVat": {
+          ".validate": "newData.isNumber()"
+        },
+        "feeRoundingDifference": {
+          ".validate": "newData.isNumber()"
+        },
+        "feeTotalGross": {
+          ".validate": "newData.isNumber()"
+        },
         "lastname": {
           ".validate": "newData.isString() && newData.val().length > 0"
         },

--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -10,8 +10,8 @@ import DetailsBox from './DetailsBox';
 import MovementField from './MovementField';
 import HomeBaseIcon from './HomeBaseIcon';
 import {getFromItemKey} from '../../util/reference-number';
-import {getLandingFeeText} from '../../util/landingFees';
 import {maskEmail, maskPhone} from '../../util/masking'
+import formatMoney from '../../util/formatMoney'
 
 const Content = styled.div`
   padding: 1.5em 1em 0 1em;
@@ -30,14 +30,18 @@ const getCarriageVoucher = props => {
   return null;
 };
 
-const getLandingFee = data => getLandingFeeText(
-  data.landingCount,
-  data.landingFeeSingle,
-  data.landingFeeTotal,
-  data.goAroundCount,
-  data.goAroundFeeSingle,
-  data.goAroundFeeTotal
-)
+const getLandingFee = data => {
+  if (typeof data.feeTotalGross === 'number') {
+    return `CHF ${formatMoney(data.feeTotalGross)}`
+  }
+
+  if (typeof data.landingFeeTotal === 'number') {
+    const total = data.landingFeeTotal + (data.goAroundFeeTotal || 0)
+    return `CHF ${formatMoney(total)}`
+  }
+
+  return null
+}
 
 class MovementDetails extends React.PureComponent {
 

--- a/src/components/wizards/ArrivalWizard/Finish/Fees.js
+++ b/src/components/wizards/ArrivalWizard/Finish/Fees.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import styled from 'styled-components'
+import formatMoney from '../../../../util/formatMoney'
+import MaterialIcon from '../../../MaterialIcon'
+
+const ExpandableDetails = styled.div`
+  padding: 1.5rem;
+  width: 400px;
+`
+
+const Amount = styled.div`
+  font-size: 1.5em;
+  margin-bottom: 1em;
+`
+
+const DetailsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`
+
+const DetailsTrigger = styled.button`
+  background-color: #eee;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  width: 100%;
+  padding: 0.4em;
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+
+  &:hover {
+    color: ${props => props.theme.colors.main};
+    background-color: ${props => props.theme.colors.background};
+  }
+`
+
+const TableContainer = styled.div`
+  margin-top: 1em;
+`
+
+const Table = styled.table`
+  width: 100%
+`
+
+const Td = styled.td`
+  padding: 0.5em 0;
+  text-align: ${props => props.align || 'left'};
+  font-size: ${props => props.fontSize || '1em'};
+  border-top: ${props => props.borderTop || 'none'};
+  border-bottom: ${props => props.borderBottom || 'none'};
+`
+
+const EmptyTd = styled.td`
+  width: 100px;
+  border-top: ${props => props.borderTop || 'none'};
+`
+
+const FeesDetails = ({fees}) => (
+  <TableContainer>
+    <Table>
+      <tbody>
+      <tr>
+        <Td fontSize="1.2em" borderBottom="1px solid" colSpan={2}>Beschreibung</Td>
+        <Td fontSize="1.2em" borderBottom="1px solid" align="right">Betrag</Td>
+      </tr>
+      <tr>
+        <Td colSpan={2}>Landung ({fees.landings} x {formatMoney(fees.landingFeeSingle)})</Td>
+        <Td align="right">{formatMoney(fees.landingFeeTotal)}</Td>
+      </tr>
+      {fees.goAroundFeeTotal > 0 && (
+        <tr>
+          <Td colSpan={2}>Durchstart ({fees.goArounds} x {formatMoney(fees.goAroundFeeSingle)})</Td>
+          <Td align="right">{formatMoney(fees.goAroundFeeTotal)}</Td>
+        </tr>
+      )}
+      {fees.totalGross > fees.totalNet && (
+        <tr>
+          <EmptyTd borderTop="1px solid"/>
+          <Td borderTop="1px solid" align="right">Subtotal</Td>
+          <Td borderTop="1px solid" align="right">{formatMoney(fees.totalNet)}</Td>
+        </tr>
+      )}
+      {fees.vat > 0 && (
+        <tr>
+          <EmptyTd/>
+          <Td align="right">MwSt (8.1%)</Td>
+          <Td align="right">{formatMoney(fees.vat)}</Td>
+        </tr>
+      )}
+      {(fees.roundingDifference > 0 || fees.roundingDifference < 0) && (
+        <tr>
+          <EmptyTd/>
+          <Td align="right">Rundungsdifferenz</Td>
+          <Td align="right">{formatMoney(fees.roundingDifference)}</Td>
+        </tr>
+      )}
+      <tr>
+        <EmptyTd borderTop={fees.totalGross === fees.totalNet ? "1px solid" : undefined}/>
+        <Td fontSize="1.2em" borderTop="1px solid" align="right">Total CHF</Td>
+        <Td fontSize="1.2em" borderTop="1px solid" align="right">{formatMoney(fees.totalGross)}</Td>
+      </tr>
+      </tbody>
+    </Table>
+  </TableContainer>
+)
+
+class Fees extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      detailsExpanded: false
+    }
+  }
+
+  render() {
+    const {fees} = this.props;
+
+    return (
+      <div>
+        <DetailsContainer>
+          <ExpandableDetails>
+            <Amount>
+              Landetaxe: CHF {formatMoney(fees.totalGross)}
+            </Amount>
+            <DetailsTrigger onClick={() => this.setState({detailsExpanded: !this.state.detailsExpanded})}>
+              <div>
+                <MaterialIcon icon={this.state.detailsExpanded ? 'expand_less' : 'expand_more'}/>
+              </div>
+              <div>
+                {this.state.detailsExpanded
+                  ? 'Details schliessen'
+                  : 'Details anzeigen'}
+              </div>
+            </DetailsTrigger>
+            {this.state.detailsExpanded && (
+              <FeesDetails fees={fees}/>
+            )}
+          </ExpandableDetails>
+        </DetailsContainer>
+      </div>
+    );
+  }
+}
+
+export default Fees

--- a/src/components/wizards/ArrivalWizard/Finish/Finish.js
+++ b/src/components/wizards/ArrivalWizard/Finish/Finish.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {getFromItemKey} from '../../../../util/reference-number';
-import {getLandingFeeText} from '../../../../util/landingFees';
 import Wrapper from './Wrapper';
 import Heading from './Heading';
-import Message, {ReferenceNumberMessage} from './Message';
+import {ReferenceNumberMessage} from './Message';
 import FinishActions from './FinishActions'
 import PaymentMethod from '../../../../containers/PaymentMethodContainer'
 import {HeadingType} from '../../MovementWizard'
+import Fees from './Fees'
 
 const getHeading = (headingType) =>
   headingType === HeadingType.UPDATED
@@ -24,6 +24,18 @@ const Finish = props => {
     itemKey,
     email,
     immatriculation,
+    fees,
+    enabledPaymentMethods,
+    invoiceRecipientName,
+    createMovementFromMovement,
+    finish
+  } = props
+  const heading = getHeading(headingType);
+
+
+  const showPayment = (isHomeBase === false || __CONF__.homebasePayment) && !isUpdate && !!fees
+
+  const {
     landings,
     landingFeeSingle,
     landingFeeCode,
@@ -32,18 +44,8 @@ const Finish = props => {
     goAroundFeeSingle,
     goAroundFeeCode,
     goAroundFeeTotal,
-    enabledPaymentMethods,
-    invoiceRecipientName,
-    createMovementFromMovement,
-    finish
-  } = props
-  const heading = getHeading(headingType);
-  const landingFeeMsg = (isHomeBase === false || __CONF__.homebasePayment)
-    ? getLandingFeeText(landings, landingFeeSingle, landingFeeTotal, goArounds, goAroundFeeSingle, goAroundFeeTotal)
-    : null;
-  const amount = (landingFeeTotal || 0) + (goAroundFeeTotal || 0)
-
-  const showPayment = (isHomeBase === false || __CONF__.homebasePayment) && !isUpdate && !!landingFeeMsg
+    totalGross
+  } = fees
 
   return (
     <Wrapper>
@@ -51,14 +53,14 @@ const Finish = props => {
       {showPayment ? (
         <>
           <ReferenceNumberMessage>Referenznummer: {getFromItemKey(itemKey)}</ReferenceNumberMessage>
-          <Message>Landetaxe: {landingFeeMsg}</Message>
+          <Fees fees={fees}/>
           <PaymentMethod
             itemKey={itemKey}
             email={email}
             immatriculation={immatriculation}
             createMovementFromMovement={createMovementFromMovement}
             finish={finish}
-            amount={amount}
+            amount={totalGross}
             landings={landings}
             landingFeeSingle={landingFeeSingle}
             landingFeeCode={landingFeeCode}
@@ -78,6 +80,21 @@ const Finish = props => {
   );
 };
 
+const feesShape = PropTypes.shape({
+  landings: PropTypes.number.isRequired,
+  landingFeeSingle: PropTypes.number,
+  landingFeeCode: PropTypes.string,
+  landingFeeTotal: PropTypes.number,
+  goArounds: PropTypes.number,
+  goAroundFeeSingle: PropTypes.number,
+  goAroundFeeCode: PropTypes.string,
+  goAroundFeeTotal: PropTypes.number,
+  totalNet: PropTypes.number,
+  vat: PropTypes.number,
+  roundingDifference: PropTypes.number,
+  totalGross: PropTypes.number
+})
+
 Finish.propTypes = {
   finish: PropTypes.func.isRequired,
   createMovementFromMovement: PropTypes.func.isRequired,
@@ -87,14 +104,7 @@ Finish.propTypes = {
   itemKey: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   immatriculation: PropTypes.string.isRequired,
-  landings: PropTypes.number.isRequired,
-  landingFeeSingle: PropTypes.number,
-  landingFeeCode: PropTypes.string,
-  landingFeeTotal: PropTypes.number,
-  goArounds: PropTypes.number,
-  goAroundFeeSingle: PropTypes.number,
-  goAroundFeeCode: PropTypes.string,
-  goAroundFeeTotal: PropTypes.number,
+  fees: feesShape.isRequired,
   localUser: PropTypes.bool,
   enabledPaymentMethods: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/src/components/wizards/ArrivalWizard/pages/FlightPage.js
+++ b/src/components/wizards/ArrivalWizard/pages/FlightPage.js
@@ -6,7 +6,7 @@ import validate from '../../validate';
 import {renderSingleSelect, renderTextArea} from '../../renderField';
 import FieldSet from '../../FieldSet';
 import WizardNavigation from '../../../WizardNavigation';
-import {getAircraftOrigin, updateGoAroundFees, updateLandingFees} from '../../../../util/landingFees';
+import {getAircraftOrigin, updateFeesTotal, updateGoAroundFees, updateLandingFees} from '../../../../util/landingFees';
 import CircuitsFieldHint from '../../CircuitsFieldHint';
 
 const FlightPage = (props) => {
@@ -29,8 +29,10 @@ const FlightPage = (props) => {
             const goAroundCount = formValues['goAroundCount'];
             const aircraftOrigin = getAircraftOrigin(formValues['immatriculation'], aircraftSettings);
 
-            updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount);
-            updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount);
+            const landingFeeTotal = updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount);
+            const goAroundFeeTotal = updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount);
+
+            updateFeesTotal(props.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory);
 
             return flightType
           }}

--- a/src/components/wizards/pages/AircraftPage.js
+++ b/src/components/wizards/pages/AircraftPage.js
@@ -6,7 +6,7 @@ import validate from '../validate';
 import {renderAircraftCategoryDropdown, renderAircraftDropdown, renderInputField} from '../renderField';
 import FieldSet from '../FieldSet';
 import WizardNavigation from '../../WizardNavigation';
-import {getAircraftOrigin, updateGoAroundFees, updateLandingFees} from '../../../util/landingFees'
+import {getAircraftOrigin, updateFeesTotal, updateGoAroundFees, updateLandingFees} from '../../../util/landingFees'
 
 const AircraftPage = (props) => {
   const { handleSubmit, formValues, aircraftSettings } = props;
@@ -29,8 +29,10 @@ const AircraftPage = (props) => {
               const goAroundCount = formValues['goAroundCount'];
               const aircraftOrigin = getAircraftOrigin(aircraft.key, aircraftSettings);
 
-              updateLandingFees(props.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, landingCount);
-              updateGoAroundFees(props.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, goAroundCount);
+              const landingFeeTotal = updateLandingFees(props.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, landingCount);
+              const goAroundFeeTotal = updateGoAroundFees(props.change, aircraft.mtow, flightType, aircraftOrigin, aircraft.category, goAroundCount);
+
+              updateFeesTotal(props.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraft.category);
 
               return aircraft.key;
             }
@@ -66,8 +68,10 @@ const AircraftPage = (props) => {
             const goAroundCount = formValues['goAroundCount']
             const aircraftOrigin = getAircraftOrigin(formValues['immatriculation'], props.aircraftSettings);
 
-            updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount)
-            updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount)
+            const landingFeeTotal = updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount)
+            const goAroundFeeTotal = updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount)
+
+            updateFeesTotal(props.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory);
 
             return mtow
           }}
@@ -84,8 +88,10 @@ const AircraftPage = (props) => {
             const goAroundCount = formValues['goAroundCount']
             const aircraftOrigin = getAircraftOrigin(formValues['immatriculation'], props.aircraftSettings);
 
-            updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount)
-            updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount)
+            const landingFeeTotal = updateLandingFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount)
+            const goAroundFeeTotal = updateGoAroundFees(props.change, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount)
+
+            updateFeesTotal(props.change, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory);
 
             return aircraftCategory
           }}

--- a/src/containers/ArrivalFinishContainer.js
+++ b/src/containers/ArrivalFinishContainer.js
@@ -36,14 +36,7 @@ class ArrivalFinishContainer extends Component {
       invoiceRecipientSettings,
       email, // pilot email (also see `authEmail`)
       immatriculation,
-      landings,
-      landingFeeSingle,
-      landingFeeCode,
-      landingFeeTotal,
-      goArounds,
-      goAroundFeeSingle,
-      goAroundFeeCode,
-      goAroundFeeTotal,
+      fees,
       createMovementFromMovement,
       finish,
       isUpdate,
@@ -84,14 +77,7 @@ class ArrivalFinishContainer extends Component {
         immatriculation={immatriculation}
         isHomeBase={isHomeBase}
         itemKey={itemKey}
-        landings={landings}
-        landingFeeSingle={landingFeeSingle}
-        landingFeeCode={landingFeeCode}
-        landingFeeTotal={landingFeeTotal}
-        goArounds={goArounds}
-        goAroundFeeSingle={goAroundFeeSingle}
-        goAroundFeeCode={goAroundFeeCode}
-        goAroundFeeTotal={goAroundFeeTotal}
+        fees={fees}
         localUser={localUser}
         enabledPaymentMethods={enabledPaymentMethods}
         invoiceRecipientName={invoiceRecipient ? invoiceRecipient.name : undefined}
@@ -99,6 +85,21 @@ class ArrivalFinishContainer extends Component {
     );
   }
 }
+
+const feesShape = PropTypes.shape({
+  landings: PropTypes.number.isRequired,
+  landingFeeSingle: PropTypes.number,
+  landingFeeCode: PropTypes.string,
+  landingFeeTotal: PropTypes.number,
+  goArounds: PropTypes.number,
+  goAroundFeeSingle: PropTypes.number,
+  goAroundFeeCode: PropTypes.string,
+  goAroundFeeTotal: PropTypes.number,
+  totalNet: PropTypes.number,
+  vat: PropTypes.number,
+  roundingDifference: PropTypes.number,
+  totalGross: PropTypes.number
+})
 
 ArrivalFinishContainer.propTypes = {
   aircraftSettings: PropTypes.shape({
@@ -122,14 +123,7 @@ ArrivalFinishContainer.propTypes = {
   itemKey: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   immatriculation: PropTypes.string.isRequired,
-  landings: PropTypes.number.isRequired,
-  landingFeeSingle: PropTypes.number,
-  landingFeeCode: PropTypes.string,
-  landingFeeTotal: PropTypes.number,
-  goArounds: PropTypes.number,
-  goAroundFeeSingle: PropTypes.number,
-  goAroundFeeCoe: PropTypes.string,
-  goAroundFeeTotal: PropTypes.number
+  fees: feesShape.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -142,14 +136,20 @@ const mapStateToProps = (state, ownProps) => {
     itemKey: state.form.wizard.values.key || state.ui.wizard.itemKey,
     email: state.form.wizard.values.email,
     immatriculation: state.form.wizard.values.immatriculation,
-    landings: state.form.wizard.values.landingCount,
-    landingFeeSingle: state.form.wizard.values.landingFeeSingle,
-    landingFeeCode: state.form.wizard.values.landingFeeCode,
-    landingFeeTotal: state.form.wizard.values.landingFeeTotal,
-    goArounds: state.form.wizard.values.goAroundCount,
-    goAroundFeeSingle: state.form.wizard.values.goAroundFeeSingle,
-    goAroundFeeCode: state.form.wizard.values.goAroundFeeCode,
-    goAroundFeeTotal: state.form.wizard.values.goAroundFeeTotal,
+    fees: {
+      landings: state.form.wizard.values.landingCount,
+      landingFeeSingle: state.form.wizard.values.landingFeeSingle,
+      landingFeeCode: state.form.wizard.values.landingFeeCode,
+      landingFeeTotal: state.form.wizard.values.landingFeeTotal,
+      goArounds: state.form.wizard.values.goAroundCount,
+      goAroundFeeSingle: state.form.wizard.values.goAroundFeeSingle,
+      goAroundFeeCode: state.form.wizard.values.goAroundFeeCode,
+      goAroundFeeTotal: state.form.wizard.values.goAroundFeeTotal,
+      totalNet: state.form.wizard.values.feeTotalNet,
+      vat: state.form.wizard.values.feeVat,
+      roundingDifference: state.form.wizard.values.feeRoundingDifference,
+      totalGross: state.form.wizard.values.feeTotalGross
+    },
     localUser: state.auth.data.local,
     authEmail: state.auth.data.email,
   });

--- a/src/util/landingFeeStrategies/default.js
+++ b/src/util/landingFeeStrategies/default.js
@@ -35,7 +35,13 @@ const getFee = (feesDefinition, mtow, flightType, aircraftOrigin) => {
   return {fee: mtowRange.fee, billingProduct: mtowRange.billingProduct};
 }
 
+/**
+ * Not implemented for the default strategy. VAT is included in fee where VAT is applicable.
+ */
+const getVatRate = (flightType, aircraftOrigin, aircraftCategory) => 0
+
 export default {
   getLandingFee,
-  getGoAroundFee
+  getGoAroundFee,
+  getVatRate
 }

--- a/src/util/landingFeeStrategies/lszm.spec.js
+++ b/src/util/landingFeeStrategies/lszm.spec.js
@@ -7,79 +7,79 @@ describe('util', () => {
       describe('getLandingFee ', () => {
         describe.each([
           // non-homebase
-          [0, 'private', AircraftOrigin.OTHER, 'Flugzeug', 24.65],
-          [0, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 24.65],
-          [800, 'private', AircraftOrigin.OTHER, 'Flugzeug', 24.65],
-          [800, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 24.65],
-          [1000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 29.85],
-          [1000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 29.85],
-          [1300, 'private', AircraftOrigin.OTHER, 'Flugzeug', 36.30],
-          [1300, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 36.30],
-          [2000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 41.50],
-          [2000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 41.50],
-          [3000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 62.25],
-          [3000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 62.25],
-          [4000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 86.9],
-          [4000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 86.9],
-          [5000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 114.15],
-          [5000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 114.15],
-          [6000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 144.0],
-          [6000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 144.0],
-          [7000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 176.4],
-          [7000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 176.4],
-          [8000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 210.15],
-          [8000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 210.15],
-          [9000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 246.45],
-          [9000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 246.45],
-          [10000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 285.4],
-          [10000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 285.4],
-          [12500, 'private', AircraftOrigin.OTHER, 'Flugzeug', 389.15],
-          [12500, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 389.15],
-          [15000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 583.75],
-          [15000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 583.75],
-          [20000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 778.3],
-          [20000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 778.3],
-          [30000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 1167.5],
-          [30000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 1167.5],
-          [40000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 1556.65],
-          [40000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 1556.65],
-          [50000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 2334.95],
-          [50000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 2334.95],
+          [0, 'private', AircraftOrigin.OTHER, 'Flugzeug', 22.8],
+          [0, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 22.8],
+          [800, 'private', AircraftOrigin.OTHER, 'Flugzeug', 22.8],
+          [800, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 22.8],
+          [1000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 27.6],
+          [1000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 27.6],
+          [1300, 'private', AircraftOrigin.OTHER, 'Flugzeug', 33.6],
+          [1300, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 33.6],
+          [2000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 38.4],
+          [2000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 38.4],
+          [3000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 57.6],
+          [3000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 57.6],
+          [4000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 80.4],
+          [4000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 80.4],
+          [5000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 105.6],
+          [5000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 105.6],
+          [6000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 133.2],
+          [6000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 133.2],
+          [7000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 163.2],
+          [7000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 163.2],
+          [8000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 194.4],
+          [8000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 194.4],
+          [9000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 228],
+          [9000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 228],
+          [10000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 264],
+          [10000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 264],
+          [12500, 'private', AircraftOrigin.OTHER, 'Flugzeug', 360],
+          [12500, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 360],
+          [15000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 540],
+          [15000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 540],
+          [20000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 720],
+          [20000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 720],
+          [30000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 1080],
+          [30000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 1080],
+          [40000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 1440],
+          [40000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 1440],
+          [50000, 'private', AircraftOrigin.OTHER, 'Flugzeug', 2160],
+          [50000, 'private', AircraftOrigin.OTHER, 'Hubschrauber', 2160],
 
           // non-homebase glider
-          [0, 'glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 24.65],
-          [10000, 'glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 24.65], // mtow doesn't matter
-          [0, 'glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 15.15], // special case: same as homebase
-          [10000, 'glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 15.15], // mtow doesn't matter
+          [0, 'glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 22.8],
+          [10000, 'glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 22.8], // mtow doesn't matter
+          [0, 'glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 14], // special case: same as homebase
+          [10000, 'glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 14], // mtow doesn't matter
           [0, 'glider_private_aerotow', AircraftOrigin.OTHER, 'Segelflugzeug', undefined], // fee due for towing plane only
           [10000, 'glider_private_aerotow', AircraftOrigin.OTHER, 'Segelflugzeug', undefined], // fee due for towing plane only
 
           // homebase plane (non instruction)
-          [0, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 20.55],
-          [800, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 20.55],
-          [1000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 24.85],
-          [1300, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 30.25],
-          [2000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 34.6],
-          [3000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 51.9],
-          [4000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 72.45],
-          [5000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 95.15],
-          [6000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 120],
-          [7000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 147],
-          [8000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 175.1],
-          [9000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 205.4],
-          [10000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 237.8],
-          [12500, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 324.3],
-          [15000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 486.45],
-          [20000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 648.6],
-          [30000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 972.9],
-          [40000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 1297.2],
-          [50000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 1945.8],
+          [0, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 19],
+          [800, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 19],
+          [1000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 23],
+          [1300, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 28],
+          [2000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 32],
+          [3000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 48],
+          [4000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 67],
+          [5000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 88],
+          [6000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 111],
+          [7000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 136],
+          [8000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 162],
+          [9000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 190],
+          [10000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 220],
+          [12500, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 300],
+          [15000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 450],
+          [20000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 600],
+          [30000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 900],
+          [40000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 1200],
+          [50000, 'private', AircraftOrigin.HOME_BASE, 'Flugzeug', 1800],
 
           // homebase glider (non instruction)
-          [0, 'glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 20.55],
-          [10000, 'glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 20.55], // mtow doesn't matter
-          [0, 'glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 15.15],
-          [10000, 'glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 15.15], // mtow doesn't matter
+          [0, 'glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 19],
+          [10000, 'glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 19], // mtow doesn't matter
+          [0, 'glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 14],
+          [10000, 'glider_private_winch', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 14], // mtow doesn't matter
           [0, 'glider_private_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', undefined], // fee due for towing plane only
           [10000, 'glider_private_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', undefined], // fee due for towing plane only
 
@@ -113,25 +113,25 @@ describe('util', () => {
           [10000, 'glider_instruction_aerotow', AircraftOrigin.HOME_BASE, 'Segelflugzeug', undefined], // fee due for towing plane only
 
           // homebase helicopter
-          [0, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 12.3],
-          [800, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 12.3],
-          [1000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 14.9],
-          [1300, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 18.15],
-          [2000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 20.75],
-          [3000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 31.15],
-          [4000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 43.45],
-          [5000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 57.1],
-          [6000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 72],
-          [7000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 88.2],
-          [8000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 105.05],
-          [9000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 123.25],
-          [10000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 142.7],
-          [12500, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 194.6],
-          [15000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 291.85],
-          [20000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 389.15],
-          [30000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 583.75],
-          [40000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 778.3],
-          [50000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 1167.5],
+          [0, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 11.4],
+          [800, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 11.4],
+          [1000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 13.8],
+          [1300, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 16.8],
+          [2000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 19.2],
+          [3000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 28.8],
+          [4000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 40.2],
+          [5000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 52.8],
+          [6000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 66.6],
+          [7000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 81.6],
+          [8000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 97.2],
+          [9000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 114],
+          [10000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 132],
+          [12500, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 180],
+          [15000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 270],
+          [20000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 360],
+          [30000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 540],
+          [40000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 720],
+          [50000, 'private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 1080],
         ])(
           'getLandingFee(%i, %s, %s)',
           (mtow, flightType, aircraftOrigin, aircraftCategory, expected) => {
@@ -141,6 +141,44 @@ describe('util', () => {
                 expect(landingFee).toBe(undefined)
               } else {
                 expect(landingFee.fee).toBe(expected);
+              }
+            });
+          }
+        )
+      })
+
+      describe('getVatRate ', () => {
+        describe.each([
+          // non-homebase
+          ['private', AircraftOrigin.OTHER, 'Flugzeug', 8.1],
+
+          // non-homebase glider
+          ['glider_private_self', AircraftOrigin.OTHER, 'Segelflugzeug', 8.1],
+          ['glider_private_winch', AircraftOrigin.OTHER, 'Segelflugzeug', 8.1],
+
+          // homebase plane (non instruction)
+          ['private', AircraftOrigin.HOME_BASE, 'Flugzeug', 8.1],
+
+          // homebase glider (non instruction)
+          ['glider_private_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 8.1],
+
+          // homebase plane (instruction)
+          ['instruction', AircraftOrigin.HOME_BASE, 'Flugzeug', 0],
+
+          // homebase glider (instruction)
+          ['glider_instruction_self', AircraftOrigin.HOME_BASE, 'Segelflugzeug', 0],
+
+          // homebase helicopter
+          ['private', AircraftOrigin.HOME_BASE, 'Hubschrauber', 8.1],
+        ])(
+          'getVatRate(%i, %s, %s)',
+          (flightType, aircraftOrigin, aircraftCategory, expected) => {
+            test(`returns ${expected}`, () => {
+              const vatRate = lszm.getVatRate(flightType, aircraftOrigin, aircraftCategory)
+              if (expected === undefined) {
+                expect(vatRate).toBe(undefined)
+              } else {
+                expect(vatRate).toBe(expected);
               }
             });
           }

--- a/src/util/landingFees.js
+++ b/src/util/landingFees.js
@@ -1,4 +1,3 @@
-import formatMoney from './formatMoney';
 import defaultGetFee from './landingFeeStrategies/default'
 import lszmGetFee from './landingFeeStrategies/lszm'
 
@@ -19,6 +18,13 @@ export const getLandingFee = (mtow, flightType, aircraftOrigin, aircraftCategory
 export const getGoAroundFee = (mtow, flightType, aircraftOrigin, aircraftCategory) =>
   strategies[__LANDING_FEES_STRATEGY__ || 'default'].getGoAroundFee(mtow, flightType, aircraftOrigin, aircraftCategory)
 
+const getTaxRate = (flightType, aircraftOrigin, aircraftCategory) =>
+  strategies[__LANDING_FEES_STRATEGY__ || 'default'].getVatRate(flightType, aircraftOrigin, aircraftCategory)
+
+const roundToFiveCents = val => Math.round(val * 20) / 20;
+
+const roundToOneCent = val => Math.round(val * 100) / 100;
+
 const updateFeeFn = (feeGetter, feeSingleField, feeTotalField, feeCodeField) =>
   (changeAction, mtow, flightType, aircraftOrigin, aircraftCategory, count) => {
     if (mtow && flightType && aircraftOrigin && aircraftCategory) {
@@ -31,21 +37,56 @@ const updateFeeFn = (feeGetter, feeSingleField, feeTotalField, feeCodeField) =>
         if (typeof count === 'number') {
           const landingFeeTotal = feeSingle.fee * count;
           changeAction(feeTotalField, landingFeeTotal);
+
+          return landingFeeTotal
         }
       }
     }
+
+    return 0
   }
 
 export const updateLandingFees = (changeAction, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount) => {
-  updateFeeFn(getLandingFee, 'landingFeeSingle', 'landingFeeTotal', 'landingFeeCode')(
+  return updateFeeFn(getLandingFee, 'landingFeeSingle', 'landingFeeTotal', 'landingFeeCode')(
     changeAction, mtow, flightType, aircraftOrigin, aircraftCategory, landingCount
   );
 }
 
 export const updateGoAroundFees = (changeAction, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount) => {
-  updateFeeFn(getGoAroundFee, 'goAroundFeeSingle', 'goAroundFeeTotal', 'goAroundFeeCode')(
+  return updateFeeFn(getGoAroundFee, 'goAroundFeeSingle', 'goAroundFeeTotal', 'goAroundFeeCode')(
     changeAction, mtow, flightType, aircraftOrigin, aircraftCategory, goAroundCount
   );
+}
+
+const getFeesTotals = (landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory) => {
+  const totalNet = landingFeeTotal + goAroundFeeTotal
+
+  const taxRate = getTaxRate(flightType, aircraftOrigin, aircraftCategory);
+
+  const vat = roundToOneCent(totalNet * (taxRate / 100))
+
+  const totalGross = totalNet + vat
+
+  const totalGrossRounded = roundToFiveCents(totalGross)
+
+  const roundingDifference = roundToOneCent(totalGrossRounded - totalGross)
+
+  return {
+    totalNet,
+    vat,
+    roundingDifference,
+    totalGrossRounded
+  }
+}
+
+export const updateFeesTotal = (changeAction, landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory) => {
+  const {totalNet, vat, roundingDifference, totalGrossRounded} =
+    getFeesTotals(landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory)
+
+  changeAction('feeTotalNet', totalNet);
+  changeAction('feeVat', vat);
+  changeAction('feeRoundingDifference', roundingDifference);
+  changeAction('feeTotalGross', totalGrossRounded);
 }
 
 export const getAircraftOrigin = (immatriculation, {club, homeBase}) => {
@@ -59,31 +100,4 @@ export const getAircraftOrigin = (immatriculation, {club, homeBase}) => {
     return AircraftOrigin.HOME_BASE;
   }
   return AircraftOrigin.OTHER;
-}
-
-export const getLandingFeeText = (
-  landings,
-  landingFeeSingle,
-  landingFeeTotal,
-  goArounds,
-  goAroundFeeSingle,
-  goAroundFeeTotal
-) => {
-  if (landingFeeTotal === undefined) {
-    return null;
-  }
-
-  if (goArounds > 0 && goAroundFeeTotal !== undefined) {
-    const total = formatMoney(landingFeeTotal + goAroundFeeTotal);
-    const landingFee = formatMoney(landingFeeSingle);
-    const goAroundFee = formatMoney(goAroundFeeSingle);
-    return `CHF ${total} (${landings} ${landings > 1 ? 'Landungen' : 'Landung'} à CHF ${landingFee} und ${goArounds} ${goArounds > 1 ? 'Durchstarts' : 'Durchstart'} à CHF ${goAroundFee})`;
-  }
-
-  const total = formatMoney(landingFeeTotal);
-  if (landings > 1) {
-    const landingFee = formatMoney(landingFeeSingle);
-    return `CHF ${total} (${landings} Landungen à CHF ${landingFee})`;
-  }
-  return `CHF ${total}`;
 }

--- a/src/util/landingFees.spec.js
+++ b/src/util/landingFees.spec.js
@@ -1,11 +1,4 @@
-import {
-  AircraftOrigin,
-  getAircraftOrigin,
-  getLandingFee,
-  getLandingFeeText,
-  updateGoAroundFees,
-  updateLandingFees
-} from './landingFees'
+import {AircraftOrigin, getAircraftOrigin, getLandingFee, updateGoAroundFees, updateLandingFees} from './landingFees'
 
 /**
  * Test landing fees defined as Jest global:
@@ -198,26 +191,6 @@ describe('util', () => {
       test('returns AircraftOrigin.OTHER if is foreign aircraft', () => {
         expect(getAircraftOrigin('HBCIY', aircraftSettings)).toBe(AircraftOrigin.OTHER);
       })
-    })
-
-    describe('getLandingFeeText', () => {
-      describe.each([
-        [undefined, undefined, undefined, undefined, undefined, undefined, null],
-        [1, 20, 20, undefined, undefined, undefined, 'CHF 20.00'],
-        [1, 20, 20, 0, 15, 0, 'CHF 20.00'],
-        [2, 20, 40, undefined, undefined, undefined, 'CHF 40.00 (2 Landungen à CHF 20.00)'],
-        [2, 20, 40, 0, 15, 0, 'CHF 40.00 (2 Landungen à CHF 20.00)'],
-        [1, 20, 20, 1, 15, 15, 'CHF 35.00 (1 Landung à CHF 20.00 und 1 Durchstart à CHF 15.00)'],
-        [1, 20, 20, 2, 15, 30, 'CHF 50.00 (1 Landung à CHF 20.00 und 2 Durchstarts à CHF 15.00)'],
-        [2, 20, 40, 2, 15, 30, 'CHF 70.00 (2 Landungen à CHF 20.00 und 2 Durchstarts à CHF 15.00)']
-      ])(
-        'getLandingFeeText(%i, %i, %i, %i, %i, %i)',
-        (landings, landingFeeSingle, landingFeeTotal, goArounds, goAroundFeeSingle, goAroundFeeTotal, expected) => {
-          test(`returns ${expected}`, () => {
-            expect(getLandingFeeText(landings, landingFeeSingle, landingFeeTotal, goArounds, goAroundFeeSingle, goAroundFeeTotal)).toBe(expected);
-          });
-        }
-      );
     })
   })
 })


### PR DESCRIPTION
- VAT is calculated by the flightbox and saved on the movement
- How it is rounded:
  - Net total: 1 cent
  - VAT: 1 cent
  - Gross total: 5 cent (rounding difference also saved on the movement)
- In Stripe checkouts we always charge the gross amount (so, the VAT is not handled by Stripe and can not be seen anywhere there - this wouldn't have worked, because we want to charge an amount rounded to 5 cents/Rappen and Stripe can't do that if it adds the VAT)
- Only handled by LSZM landing fees correctly at this point (VAT is always 0 for LSZT and LSPV at this stage - even though the charged amount might contain VAT)