### PR TITLE
Prevent NaN fee totals when saving arrival with undefined go around fee

### DIFF
--- a/src/util/landingFees.js
+++ b/src/util/landingFees.js
@@ -58,7 +58,7 @@ export const updateGoAroundFees = (changeAction, mtow, flightType, aircraftOrigi
   );
 }
 
-const getFeesTotals = (landingFeeTotal, goAroundFeeTotal, flightType, aircraftOrigin, aircraftCategory) => {
+const getFeesTotals = (landingFeeTotal = 0, goAroundFeeTotal = 0, flightType, aircraftOrigin, aircraftCategory) => {
   const totalNet = landingFeeTotal + goAroundFeeTotal
 
   const taxRate = getTaxRate(flightType, aircraftOrigin, aircraftCategory);


### PR DESCRIPTION
If `goAroundFeeTotal` is undefined, `0` should be used as a fallback. Otherwise, `totalNet` will be NaN, because NaN is the result if you add `undefined` to a number.