### PR TITLE
Fix setting aircraft fields on selection of suggestion in aircraft page

### DIFF
--- a/src/components/wizards/pages/AircraftPage.js
+++ b/src/components/wizards/pages/AircraftPage.js
@@ -20,11 +20,11 @@ const AircraftPage = (props) => {
           readOnly={props.readOnly}
           normalize={aircraft => {
             if (aircraft) {
-              if (formValues['type'] === 'arrival') {
-                props.change('aircraftType', aircraft.type);
-                props.change('mtow', aircraft.mtow);
-                props.change('aircraftCategory', aircraft.category)
+              props.change('aircraftType', aircraft.type);
+              props.change('mtow', aircraft.mtow);
+              props.change('aircraftCategory', aircraft.category)
 
+              if (formValues['type'] === 'arrival') {
                 const flightType = formValues['flightType'];
                 const landingCount = formValues['landingCount'];
                 const goAroundCount = formValues['goAroundCount'];


### PR DESCRIPTION
The fields aircraftType, MTOW, and aircraftCategory should always be filled out, no matter if the movement is an arrival or a departure.