### PR TITLE
Show "Zahlung offen" tag and payment link if no payment method set

### DIFF
--- a/src/components/MovementList/Movement.js
+++ b/src/components/MovementList/Movement.js
@@ -57,6 +57,7 @@ class Movement extends React.PureComponent {
           onDelete={props.onDelete}
           locked={props.locked}
           isHomeBase={isHomeBase}
+          isAdmin={props.isAdmin}
         />
         {props.selected && (
           <div>

--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import dates from '../../util/dates';
 import {getLabel as getFlightTypeLabel} from '../../util/flightTypes';
+import {getLabel as getPaymentMethodLabel} from '../../util/paymentMethods';
 import {getArrivalRouteLabel, getDepartureRouteLabel} from '../../util/routes';
 import {getItemLabel as getCarriageVoucherItemLabel} from '../../util/carriageVoucher';
 import newLineToBr from '../../util/newLineToBr';
@@ -12,6 +13,7 @@ import HomeBaseIcon from './HomeBaseIcon';
 import {getFromItemKey} from '../../util/reference-number';
 import {maskEmail, maskPhone} from '../../util/masking'
 import formatMoney from '../../util/formatMoney'
+import NoPaymentFieldValue from './NoPaymentFieldValue'
 
 const Content = styled.div`
   padding: 1.5em 1em 0 1em;
@@ -54,6 +56,8 @@ class MovementDetails extends React.PureComponent {
 
     const date = dates.formatDate(props.data.date);
     const time = dates.formatTime(props.data.date, props.data.time);
+
+    const showPaymentMethod = (props.isAdmin || !props.data.paymentMethod) && (props.isHomeBase === false || __CONF__.homebasePayment)
 
     return (
         <Content className={props.className}>
@@ -123,6 +127,14 @@ class MovementDetails extends React.PureComponent {
             <DetailsBox label="Gebühren">
               <MovementField label="Referenznummer" value={getFromItemKey(props.data.key)}/>
               <MovementField label="Landetaxe" value={getLandingFee(props.data)}/>
+              {showPaymentMethod && (
+                <MovementField
+                  label="Zahlungsart"
+                  value={props.data.paymentMethod
+                    ? getPaymentMethodLabel(props.data.paymentMethod)
+                    : <NoPaymentFieldValue arrivalId={props.data.key}/>}
+                />
+              )}
             </DetailsBox>
           )}
         </Content>

--- a/src/components/MovementList/MovementHeader.js
+++ b/src/components/MovementList/MovementHeader.js
@@ -6,13 +6,22 @@ import Action from './Action';
 import MaterialIcon from '../MaterialIcon';
 import HomeBaseIcon from './HomeBaseIcon';
 import {ACTION_LABELS, TYPE_LABELS} from './labels';
+import NoPaymentTag from './NoPaymentTag'
 
 const ICON_HEIGHT = 30;
 
+const TagsWrapper = styled.div`
+  padding: 0 1em 0.5em 1em;
+  display: flex;
+`
+
 const Wrapper = styled.div`
+  cursor: pointer;
+`
+
+const ColumnsWrapper = styled.div`
   padding: 1em;
   overflow: hidden;
-  cursor: pointer;
   display: flex;
   ${props => props.selected && `
     font-weight: bold;
@@ -131,56 +140,72 @@ class MovementHeader extends React.PureComponent {
       : null;
     const time = dates.formatTime(props.data.date, props.data.time);
 
+    const showPayment = (props.isHomeBase === false || __CONF__.homebasePayment)
+    const paymentMissing = showPayment
+      && props.data.type === 'arrival'
+      && props.data.landingFeeTotal !== undefined
+      && !props.data.paymentMethod
+    const hasTags = paymentMissing
+
     return (
       <Wrapper
         onClick={props.onClick}
         selected={props.selected}
-        locked={props.locked}
-        hasAssociatedMovement={
-          props.data.associatedMovement
-          && ['departure', 'arrival'].includes(props.data.associatedMovement.type)
-        }
-      >
-        <Column className="type">
-          <MaterialIcon
-            icon={TYPE_LABELS[props.data.type].icon}
-            size={ICON_HEIGHT}
-            title={TYPE_LABELS[props.data.type].label}
-          />
-        </Column>
-        <Column className="immatriculation" alignMiddle>{props.data.immatriculation}</Column>
-        <Column className="homebase" alignMiddle>
-          <HomeBaseIcon isHomeBase={props.isHomeBase}/>
-        </Column>
-        <Column className="pilot" alignMiddle>{props.data.lastname}</Column>
-        <Column className="datetime" alignMiddle={!date}>
-          {date && <Date className="date">{date}</Date>}
-          <div className="time">{time}</div>
-        </Column>
-        <Column className="location" alignMiddle>{getLocation(props.data)}</Column>
-        <ActionColumn className="action" alignMiddle highlight>
-          {props.data.associatedMovement && props.data.associatedMovement.type === 'none' ? (
-            <Action
-              label={ACTION_LABELS[props.data.type].label}
-              icon={ACTION_LABELS[props.data.type].icon}
-              onClick={this.handleActionClick}
-              responsive
-            />
-          ) : props.data.associatedMovement === null
-            ? <MaterialIcon icon="sync" rotate="left"/> // show rotating icon if `associatedMovement` is null (= state where the associated movement is being monitored, but not set yet)
-            : null // if `associatedMovement` is undefined, we don't want to show anything (= state before the associated movement is even being monitored)
+        locked={props.locked}>
+        <ColumnsWrapper
+          hasAssociatedMovement={
+            props.data.associatedMovement
+            && ['departure', 'arrival'].includes(props.data.associatedMovement.type)
           }
-        </ActionColumn>
-        <ActionColumn className="delete" alignMiddle>
-          {!props.locked && (
-            <Action
-              label="Löschen"
-              icon="delete"
-              onClick={this.handleDeleteClick}
-              responsive
+        >
+          <Column className="type">
+            <MaterialIcon
+              icon={TYPE_LABELS[props.data.type].icon}
+              size={ICON_HEIGHT}
+              title={TYPE_LABELS[props.data.type].label}
             />
-          )}
-        </ActionColumn>
+          </Column>
+          <Column className="immatriculation" alignMiddle>{props.data.immatriculation}</Column>
+          <Column className="homebase" alignMiddle>
+            <HomeBaseIcon isHomeBase={props.isHomeBase}/>
+          </Column>
+          <Column className="pilot" alignMiddle>{props.data.lastname}</Column>
+          <Column className="datetime" alignMiddle={!date}>
+            {date && <Date className="date">{date}</Date>}
+            <div className="time">{time}</div>
+          </Column>
+          <Column className="location" alignMiddle>{getLocation(props.data)}</Column>
+          <ActionColumn className="action" alignMiddle highlight>
+            {props.data.associatedMovement && props.data.associatedMovement.type === 'none' ? (
+              <Action
+                label={ACTION_LABELS[props.data.type].label}
+                icon={ACTION_LABELS[props.data.type].icon}
+                onClick={this.handleActionClick}
+                responsive
+              />
+            ) : props.data.associatedMovement === null
+              ? <MaterialIcon icon="sync" rotate="left"/> // show rotating icon if `associatedMovement` is null (= state where the associated movement is being monitored, but not set yet)
+              : null // if `associatedMovement` is undefined, we don't want to show anything (= state before the associated movement is even being monitored)
+            }
+          </ActionColumn>
+          <ActionColumn className="delete" alignMiddle>
+            {!props.locked && (
+              <Action
+                label="Löschen"
+                icon="delete"
+                onClick={this.handleDeleteClick}
+                responsive
+              />
+            )}
+          </ActionColumn>
+        </ColumnsWrapper>
+        {hasTags && (
+          <TagsWrapper>
+            {props.isAdmin && paymentMissing && (
+              <NoPaymentTag/>
+            )}
+          </TagsWrapper>
+        )}
       </Wrapper>
     );
   }
@@ -201,7 +226,8 @@ MovementHeader.propTypes = {
   onDelete: PropTypes.func.isRequired,
   locked: PropTypes.bool,
   onClick: PropTypes.func,
-  isHomeBase: PropTypes.bool.isRequired
+  isHomeBase: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired
 };
 
 export default MovementHeader;

--- a/src/components/MovementList/NoPaymentFieldValue.js
+++ b/src/components/MovementList/NoPaymentFieldValue.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {Link} from 'react-router-dom'
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`
+
+const StyledLink = styled(Link)`
+  text-decoration: underline;
+  font-size: 0.95em;
+`
+
+const FieldValue = styled.div`
+  color: ${props => props.theme.colors.danger};
+`
+
+const NoPaymentFieldValue = ({arrivalId}) => (
+  <Wrapper>
+    <FieldValue>Zahlung offen</FieldValue>
+    <div><StyledLink to={`/arrival/${arrivalId}/payment`}>Jetzt bezahlen</StyledLink></div>
+  </Wrapper>
+);
+
+NoPaymentFieldValue.propTypes = {
+  arrivalId: PropTypes.string.isRequired,
+}
+
+export default NoPaymentFieldValue;

--- a/src/components/MovementList/NoPaymentTag.js
+++ b/src/components/MovementList/NoPaymentTag.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  color: ${props => props.theme.colors.danger};
+  background-color: ${props => props.theme.colors.danger}10;
+  border: 1px solid ${props => props.theme.colors.danger}20;
+  border-radius: 9999px;
+  font-size: 0.9em;
+  padding: 0.3rem 0.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const NoPaymentTag = () => (
+  <Wrapper>Zahlung offen</Wrapper>
+);
+
+export default NoPaymentTag;

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
@@ -9,27 +9,7 @@ import FinishActions from './FinishActions'
 import TwintPaymentMessage from './TwintPaymentMessage'
 import {withRouter} from 'react-router-dom'
 import {getFromItemKey} from '../../../../util/reference-number'
-
-const PAYMENT_METHODS = [{
-  label: 'Karte',
-  value: 'card'
-},
-  {
-    label: 'Direkt zahlen',
-    value: 'checkout'
-  },
-  {
-    label: 'Bar',
-    value: 'cash'
-  },
-  {
-    label: 'Twint',
-    value: 'twint_external'
-  },
-  {
-    label: 'Rechnung',
-    value: 'invoice'
-  }]
+import {PAYMENT_METHODS} from '../../../../util/paymentMethods'
 
 const Container = styled.div`
 `
@@ -229,8 +209,11 @@ class PaymentMethod extends Component {
                   .filter(method => enabledPaymentMethods.includes(method.value))
                   .map(method => method.value === 'invoice' ? ({
                     ...method,
-                    label: `${method.label} (${invoiceRecipientName})`
-                  }) : method)}
+                    label: `${method.ctaLabel ||method.label} (${invoiceRecipientName})`
+                  }) : {
+                    ...method,
+                    label: method.ctaLabel || method.label
+                  })}
                 orientation="vertical"
                 onChange={e => setMethod(e.target.value)}
                 value={method}

--- a/src/util/paymentMethods.js
+++ b/src/util/paymentMethods.js
@@ -1,0 +1,37 @@
+export const PAYMENT_METHODS = [
+  {
+    label: 'Karte',
+    value: 'card'
+  },
+  {
+    ctaLabel: 'Direkt zahlen',
+    label: 'Online-Zahlung',
+    value: 'checkout'
+  },
+  {
+    label: 'Bar',
+    value: 'cash'
+  },
+  {
+    label: 'Twint',
+    value: 'twint_external'
+  },
+  {
+    label: 'Rechnung',
+    value: 'invoice'
+  }
+]
+
+export const getLabel = (value) => {
+  const method = PAYMENT_METHODS.find(method => method.value === value.method)
+
+  if (!method) {
+    return value.method
+  }
+
+  if (method.value === 'invoice') {
+    return `${method.label} (${value.invoiceRecipientName})`
+  }
+
+  return method.label
+}


### PR DESCRIPTION
After saving an arrival, the payment screen is shown to the user. Some users seem to leave this screen without paying (or setting the payment method "invoice"). We now mark those arrivals accordingly where this had been the case. There is also a link shown on the arrival details for these arrivals to return to the payment screen.

Note that if a payment method like "checkout" or "card" is selected, they could still have cancelled the payment and the payment could still be open, even though we don't show "Zahlung offen" in this case, because the payment method would be set. This is something we will address later.