### PR TITLE
Add payment status for online checkout payments

### DIFF
--- a/src/components/MovementList/MovementDetails.js
+++ b/src/components/MovementList/MovementDetails.js
@@ -130,7 +130,7 @@ class MovementDetails extends React.PureComponent {
               {showPaymentMethod && (
                 <MovementField
                   label="Zahlungsart"
-                  value={props.data.paymentMethod
+                  value={props.data.paymentMethod && props.data.paymentMethod.status !== 'pending'
                     ? getPaymentMethodLabel(props.data.paymentMethod)
                     : <NoPaymentFieldValue arrivalId={props.data.key}/>}
                 />

--- a/src/components/MovementList/MovementHeader.js
+++ b/src/components/MovementList/MovementHeader.js
@@ -144,7 +144,7 @@ class MovementHeader extends React.PureComponent {
     const paymentMissing = showPayment
       && props.data.type === 'arrival'
       && props.data.landingFeeTotal !== undefined
-      && !props.data.paymentMethod
+      && (!props.data.paymentMethod || props.data.paymentMethod.status === 'pending')
     const hasTags = paymentMissing
 
     return (

--- a/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
+++ b/src/components/wizards/ArrivalWizard/Finish/PaymentMethod.js
@@ -63,6 +63,10 @@ class PaymentMethod extends Component {
     if (successParam === 'true') {
       this.props.setMethod('checkout')
       this.props.setStep(Step.COMPLETED)
+      this.props.saveMovementPaymentMethod('arrival', this.props.itemKey, {
+        method: 'checkout',
+        status: 'completed'
+      })
       return
     }
 
@@ -128,6 +132,7 @@ class PaymentMethod extends Component {
         goAroundFeeTotal
       )
     } else if (method === 'checkout') {
+      paymentMethodData.status = 'pending'
       setStep(Step.CONFIRMED)
       createCardPayment(
         itemKey,


### PR DESCRIPTION
- The payment method object on the arrival is now created with status `pending` if the method is `checkout`. As long as it has this status, the landing fee payment is marked as pending in the movement list.
- Once Stripe navigates back the Flightbox with the success status, we update the status to `completed`