### PR TITLE
Only show online payments in invoices report if not pending anymore

### DIFF
--- a/src/util/InvoicesReport.js
+++ b/src/util/InvoicesReport.js
@@ -140,7 +140,7 @@ class InvoicesReport {
 
     arrivals.forEach(record => {
       const arrival = firebaseToLocal(record.val());
-      if (arrival.paymentMethod) {
+      if (arrival.paymentMethod && arrival.paymentMethod.status !== 'pending') {
         filtered.push(arrival)
       }
     });


### PR DESCRIPTION
Once the fee has actually been paid (not just payment method selected), the status changes from `pending` to `completed` and then the flight appears in the invoices report.