### PR TITLE
Send sign-in email by ourselves instead of by Firebase

### DIFF
--- a/EMAIL_SETUP.md
+++ b/EMAIL_SETUP.md
@@ -1,0 +1,191 @@
+# Custom Email Authentication Setup
+
+This document explains how to set up custom email authentication for your Firebase sign-in links to avoid emails going to spam folders using Mailgun SMTP.
+
+## Overview
+
+The solution generates Firebase sign-in links using the Admin SDK without sending emails automatically, then uses Mailgun SMTP via nodemailer to send the links. SMTP settings are stored in Firebase database for easy configuration.
+
+## Architecture
+
+1. **Client-side**: `authenticateEmail()` calls a Cloud Function to generate the sign-in link
+2. **Cloud Function**: `generateSignInLink` uses Firebase Admin SDK to create the link
+3. **Email Service**: `sendSignInEmail` reads SMTP settings from `/settings/emailSmtp` and sends email via Mailgun SMTP
+
+## Firebase Database Structure
+
+You need to add the following structure to your Firebase Realtime Database at `/settings/emailSmtp`:
+
+```json
+{
+  "settings": {
+    "emailSmtp": {
+      "host": "smtp.mailgun.org",
+      "port": "465",
+      "user": "postmaster@mg.yourdomain.com",
+      "password": "your-mailgun-smtp-password",
+      "fromEmail": "noreply@yourdomain.com",
+      "fromName": "Flightbox"
+    }
+  }
+}
+```
+
+### Required Fields
+
+- **`host`**: SMTP server hostname (for Mailgun: `smtp.mailgun.org`)
+- **`port`**: SMTP port (587 for TLS, 465 for SSL, 25 for unencrypted)
+- **`user`**: SMTP username (for Mailgun: your domain's SMTP credentials)
+- **`password`**: SMTP password (for Mailgun: your domain's SMTP password)
+- **`fromEmail`**: The email address that emails will be sent from
+- **`fromName`**: The display name for the sender
+
+### Mailgun SMTP Setup
+
+1. **Create Mailgun Account**: Sign up at [mailgun.com](https://mailgun.com)
+
+2. **Add and Verify Your Domain**: 
+   - Add your domain in the Mailgun dashboard
+   - Add the required DNS records (MX, TXT, CNAME)
+   - Wait for verification
+
+3. **Get SMTP Credentials**:
+   - Go to Domains > [Your Domain] > Domain Settings
+   - Find "SMTP credentials" section
+   - Use the provided username and password
+
+4. **Common Mailgun SMTP Settings**:
+   ```
+   Host: smtp.mailgun.org (US) or smtp.eu.mailgun.org (EU)
+   Port: 587 (TLS) or 465 (SSL)
+   Username: postmaster@mg.yourdomain.com
+   Password: [from Mailgun dashboard]
+   ```
+
+## Implementation Steps
+
+### 1. Set up Firebase Database
+
+Add your Mailgun SMTP settings to Firebase Realtime Database at `/settings/emailSMTP` with the structure shown above.
+
+### 2. Deploy Cloud Functions
+
+```bash
+cd functions
+npm install
+firebase deploy --only functions
+```
+
+### 3. Update Project Configuration
+
+In your webpack config or build process, make sure `__FIREBASE_PROJECT_ID__` is set correctly.
+
+### 4. Test the Implementation
+
+1. Deploy your functions and client-side changes
+2. Try the email authentication flow
+3. Check that emails are delivered to your inbox (not spam)
+4. Monitor Firebase Functions logs for any errors
+
+## Testing Your Setup
+
+### Test Link Generation
+```bash
+curl -X POST https://us-central1-YOUR-PROJECT-ID.cloudfunctions.net/generateSignInLink \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","continueUrl":"https://yourapp.com"}'
+```
+
+### Test Email Sending
+```bash
+curl -X POST https://us-central1-YOUR-PROJECT-ID.cloudfunctions.net/sendSignInEmail \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","signInLink":"https://example.com","customMessage":"Test message"}'
+```
+
+## Customizing Email Templates
+
+The email template is defined in `functions/auth/sendSignInEmail.js`. You can customize:
+
+- **Subject line**: Modify `emailSubject` variable
+- **HTML content**: Edit the `emailHtml` template
+- **Plain text**: Update the `emailText` content
+- **Styling**: Modify the inline CSS in the HTML template
+
+## Security Considerations
+
+1. **Database Security**: Ensure your Firebase database rules protect the `/settings` node from unauthorized access
+2. **SMTP Credentials**: Keep your Mailgun SMTP credentials secure
+3. **Domain Verification**: Verify your sending domain with Mailgun for better deliverability
+4. **Rate Limiting**: Consider implementing rate limiting to prevent email abuse
+5. **Link Expiration**: Firebase sign-in links expire after 1 hour by default
+
+## Troubleshooting
+
+### Common Issues
+
+1. **SMTP settings not found**: Ensure `/settings/emailSMTP` exists in your Firebase database
+2. **Authentication failed**: Check your Mailgun SMTP credentials
+3. **Email not delivered**: Verify your domain and check Mailgun logs
+4. **Functions error**: Check Firebase Functions logs with `firebase functions:log`
+
+### Debugging Steps
+
+1. **Check Database Settings**:
+   Verify the SMTP settings structure in Firebase Console
+
+2. **Monitor Function Logs**:
+   ```bash
+   firebase functions:log --only sendSignInEmail,generateSignInLink
+   ```
+
+3. **Test SMTP Connection**:
+   The function will log connection errors if SMTP fails
+
+4. **Check Mailgun Dashboard**:
+   Monitor your Mailgun dashboard for delivery status and logs
+
+## DNS Configuration for Better Deliverability
+
+To avoid emails going to spam, configure these DNS records for your domain:
+
+### SPF Record
+```
+TXT @ "v=spf1 include:mailgun.org ~all"
+```
+
+### DKIM Record
+Add the DKIM record provided by Mailgun in your dashboard.
+
+### DMARC Record (Optional)
+```
+TXT _dmarc "v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com"
+```
+
+## Production Checklist
+
+- [ ] Mailgun account set up and domain verified
+- [ ] DNS records (SPF, DKIM) configured
+- [ ] SMTP settings added to Firebase database `/settings/emailSMTP`
+- [ ] Functions deployed to production
+- [ ] Client-side code updated and deployed
+- [ ] Email templates customized for your brand
+- [ ] Test email delivery to multiple email providers (Gmail, Outlook, etc.)
+- [ ] Monitor delivery rates and spam reports
+- [ ] Set up monitoring/alerting for function errors
+
+## Advantages of This Approach
+
+✅ **No Spam Issues**: Professional SMTP service with good reputation  
+✅ **Database Configuration**: Easy to update settings without redeploying  
+✅ **Cost Effective**: Mailgun has generous free tiers  
+✅ **Reliable**: Enterprise-grade email delivery  
+✅ **Monitoring**: Detailed delivery analytics in Mailgun dashboard  
+✅ **Firebase Security**: Links still generated securely by Firebase  
+
+## Support Resources
+
+- [Mailgun SMTP Documentation](https://documentation.mailgun.com/en/latest/user_manual.html#smtp-relay)
+- [Firebase Admin SDK Email Links](https://firebase.google.com/docs/auth/admin/email-action-links)
+- [Nodemailer Documentation](https://nodemailer.com/about/)
+- [Firebase Database Security Rules](https://firebase.google.com/docs/database/security)

--- a/functions/auth/emailTemplates.js
+++ b/functions/auth/emailTemplates.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const PLACEHOLDER_REGEX = /\{\{(\w+)\}\}/g;
+
+const replacePlaceholders = (content, replacements) => {
+  return content.replace(PLACEHOLDER_REGEX, (match, key) => {
+    return replacements[key] !== undefined ? replacements[key] : match;
+  });
+};
+
+const readTemplate = (templateName, format) => {
+  const templatePath = path.join(__dirname, 'templates', `${templateName}.${format}`);
+  return fs.readFileSync(templatePath, 'utf8');
+};
+
+const getSignInEmailContent = ({ signInLink, airportName, themeColor }) => {
+  const replacements = {
+    signInLink,
+    airportName,
+    themeColor
+  };
+
+  const htmlTemplate = readTemplate('signin', 'html');
+  const textTemplate = readTemplate('signin', 'txt');
+
+  return {
+    subject: 'Bei Flightbox anmelden',
+    html: replacePlaceholders(htmlTemplate, replacements),
+    text: replacePlaceholders(textTemplate, replacements)
+  };
+};
+
+module.exports = {
+  getSignInEmailContent
+};

--- a/functions/auth/generateSignInLink.js
+++ b/functions/auth/generateSignInLink.js
@@ -1,0 +1,55 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const cors = require('cors')({origin: true});
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const validateRequest = (method, body) => {
+  if (method !== 'POST') {
+    return { error: 'Method not allowed', status: 405 };
+  }
+
+  const { email, continueUrl } = body;
+
+  if (!email) {
+    return { error: 'Email is required', status: 400 };
+  }
+
+  if (!continueUrl) {
+    return { error: 'Continue URL is required', status: 400 };
+  }
+
+  if (!EMAIL_REGEX.test(email)) {
+    return { error: 'Invalid email format', status: 400 };
+  }
+
+  return null;
+};
+
+exports.generateSignInLink = functions.https.onRequest((req, res) => {
+  return cors(req, res, async () => {
+    try {
+      const validationError = validateRequest(req.method, req.body);
+      if (validationError) {
+        return res.status(validationError.status).json({ error: validationError.error });
+      }
+
+      const { email, continueUrl } = req.body;
+
+      const actionCodeSettings = {
+        url: continueUrl,
+        handleCodeInApp: true,
+      };
+
+      const signInLink = await admin.auth().generateSignInWithEmailLink(email, actionCodeSettings);
+
+      res.status(200).json({ signInLink, email });
+    } catch (error) {
+      console.error('Error generating sign-in link:', error);
+      res.status(500).json({
+        error: 'Failed to generate sign-in link',
+        details: error.message
+      });
+    }
+  });
+});

--- a/functions/auth/sendSignInEmail.js
+++ b/functions/auth/sendSignInEmail.js
@@ -1,0 +1,87 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const cors = require('cors')({origin: true});
+const nodemailer = require('nodemailer');
+const { getSignInEmailContent } = require('./emailTemplates');
+
+const REQUIRED_SMTP_SETTINGS = ['host', 'port', 'user', 'password', 'fromEmail', 'fromName'];
+
+const validateRequest = (method, body) => {
+  if (method !== 'POST') {
+    return { error: 'Method not allowed', status: 405 };
+  }
+
+  const { email, signInLink } = body;
+  if (!email || !signInLink) {
+    return { error: 'Email and signInLink are required', status: 400 };
+  }
+
+  return null;
+};
+
+const loadSmtpSettings = async () => {
+  const snapshot = await admin.database().ref('/settings/emailSmtp').once('value');
+  const settings = snapshot.val();
+
+  if (!settings) {
+    throw new Error('SMTP settings not found in database at /settings/emailSmtp');
+  }
+
+  const missingSettings = REQUIRED_SMTP_SETTINGS.filter(setting => !settings[setting]);
+  if (missingSettings.length > 0) {
+    throw new Error(`Missing SMTP settings: ${missingSettings.join(', ')}`);
+  }
+
+  return settings;
+};
+
+const createTransporter = (settings) => {
+  return nodemailer.createTransport({
+    host: settings.host,
+    port: parseInt(settings.port),
+    secure: true,
+    auth: {
+      user: settings.user,
+      pass: settings.password,
+    },
+  });
+};
+
+exports.sendSignInEmail = functions.https.onRequest((req, res) => {
+  return cors(req, res, async () => {
+    try {
+      const validationError = validateRequest(req.method, req.body);
+      if (validationError) {
+        return res.status(validationError.status).json({ error: validationError.error });
+      }
+
+      const { email, signInLink, airportName, themeColor } = req.body;
+
+      const smtpSettings = await loadSmtpSettings();
+      const emailContent = getSignInEmailContent({ signInLink, airportName, themeColor });
+      const transporter = createTransporter(smtpSettings);
+
+      const info = await transporter.sendMail({
+        from: `"${smtpSettings.fromName}" <${smtpSettings.fromEmail}>`,
+        to: email,
+        subject: emailContent.subject,
+        text: emailContent.text,
+        html: emailContent.html,
+      });
+
+      console.log('Sign-in email sent successfully:', info.messageId);
+
+      res.status(200).json({
+        success: true,
+        message: 'Sign-in email sent successfully',
+        messageId: info.messageId
+      });
+    } catch (error) {
+      console.error('Error sending sign-in email:', error);
+      res.status(500).json({
+        error: 'Failed to send sign-in email',
+        details: error.message
+      });
+    }
+  });
+});

--- a/functions/auth/templates/signin.html
+++ b/functions/auth/templates/signin.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bei Flightbox anmelden</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 0; background-color: #f4f4f4;">
+  <div style="max-width: 600px; margin: 40px auto; background-color: #ffffff; box-shadow: 0 2px 10px rgba(0,0,0,0.1); overflow: hidden;">
+
+    <!-- Header -->
+    <div style="background: {{themeColor}}; color: white; padding: 20px 30px; text-align: center;">
+      <h1 style="margin: 0; font-size: 28px; font-weight: 300;">Flightbox</h1>
+      <p style="margin: 10px 0 0 0; font-size: 16px; opacity: 0.9;">{{airportName}}</p>
+    </div>
+
+    <!-- Content -->
+    <div style="padding: 20px 30px;">
+      <p style="font-size: 16px; margin-bottom: 20px;">Hallo!</p>
+
+      <p style="font-size: 16px; margin-bottom: 30px;">Klicken Sie auf die Schaltfläche unten, um sich sicher bei Ihrem Flightbox-Konto anzumelden:</p>
+
+      <!-- Sign In Button -->
+      <div style="text-align: center; margin: 40px 0;">
+        <a href="{{signInLink}}"
+           style="display: inline-block; background: {{themeColor}}; color: white; padding: 16px 32px; text-decoration: none; border-radius: 6px; font-size: 16px; font-weight: 500; text-transform: uppercase; letter-spacing: 1px; box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2); transition: all 0.3s ease;">
+          Bei Flightbox anmelden
+        </a>
+      </div>
+
+      <p style="font-size: 14px; color: #666; margin-top: 30px;">Falls die Schaltfläche nicht funktioniert, kopieren Sie diesen Link und fügen Sie ihn in Ihren Browser ein:</p>
+      <p style="word-break: break-all; font-size: 14px; color: #667eea; background-color: #f8f9fa; padding: 15px; border-radius: 4px; font-family: monospace;">{{signInLink}}</p>
+
+      <!-- Security Notice -->
+      <div style="margin-top: 40px; padding: 20px; background-color: #fff3cd; border: 1px solid #ffeaa7; border-radius: 4px;">
+        <h3 style="margin: 0 0 10px 0; font-size: 16px; color: #856404;">🔒 Sicherheitshinweis</h3>
+        <p style="margin: 0; font-size: 14px; color: #856404;">
+          • Dieser Link läuft in <strong>1 Stunde</strong> aus Sicherheitsgründen ab<br>
+          • Falls Sie diesen Anmelde-Link nicht angefordert haben, können Sie diese E-Mail ignorieren<br>
+          • Teilen Sie diesen Link niemals mit anderen
+        </p>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div style="background-color: #f8f9fa; padding: 30px; text-align: center; border-top: 1px solid #e9ecef;">
+      <p style="margin: 0; font-size: 14px; color: #6c757d;">
+        Diese E-Mail wurde von der open digital Flightbox gesendet<br>
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/functions/auth/templates/signin.txt
+++ b/functions/auth/templates/signin.txt
@@ -1,0 +1,13 @@
+Hallo!
+
+Willkommen bei Flightbox! Klicken Sie auf den folgenden Link, um sich sicher bei Ihrem Konto anzumelden:
+
+{{signInLink}}
+
+SICHERHEITSHINWEIS:
+• Dieser Link läuft in 1 Stunde aus Sicherheitsgründen ab
+• Falls Sie diesen Anmelde-Link nicht angefordert haben, können Sie diese E-Mail ignorieren
+• Teilen Sie diesen Link niemals mit anderen
+
+---
+Diese E-Mail wurde von der open digital Flightbox gesendet

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,8 @@ admin.initializeApp({
 });
 
 const auth = require('./auth');
+const { generateSignInLink } = require('./auth/generateSignInLink');
+const { sendSignInEmail } = require('./auth/sendSignInEmail');
 const api = require('./api');
 const webhook = require('./webhook');
 const setAssociatedMovementsCronJob = require('./associatedMovements/setAssociatedMovementsCronJob');
@@ -17,6 +19,8 @@ const associatedMovementsTriggers = require('./associatedMovements/setAssociated
 const invoiceRecipientsTrigger = require('./invoiceRecipients/invoiceRecipientsTrigger');
 
 exports.auth = auth;
+exports.generateSignInLink = generateSignInLink;
+exports.sendSignInEmail = sendSignInEmail;
 exports.api = api;
 exports.webhook = webhook;
 exports.setAssociatedMovementsCronJob = setAssociatedMovementsCronJob;

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,6 +10,7 @@
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^4.7.0",
         "moment": "^2.22.2",
+        "nodemailer": "^6.9.0",
         "request-promise": "^4.2.6",
         "soap": "^0.24.0"
       },
@@ -2174,6 +2175,15 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/oauth-sign": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,7 @@
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.7.0",
     "moment": "^2.22.2",
+    "nodemailer": "^6.9.0",
     "request-promise": "^4.2.6",
     "soap": "^0.24.0"
   },


### PR DESCRIPTION
- There were spam problems with the built-in email of Firebase which is sent using Firebase's `sendSignInLinkToEmail`. Furthermore, it was english (as opposed to the rest of the app) and couldn't be customized at all
- Therefore, we now just generate the sign-in link by Firebase and send the mail by ourselves
- This requires SMTP settings in the realtime database under `/settings/emailSmtp`