### PR TITLE
Improve styling of headers and add "Flightbox" and aerodrome name

### DIFF
--- a/src/components/ImageButton/OptionalLink.js
+++ b/src/components/ImageButton/OptionalLink.js
@@ -8,10 +8,10 @@ const StyledLink = styled(Link)`
   cursor: pointer;
   margin: 0 1em;
   padding: 1em;
-  border-radius: 10px;
 
   &:hover {
     background-color: ${props => props.theme.colors.background};
+    box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
   }
 `;
 

--- a/src/components/LoginPage/Header.js
+++ b/src/components/LoginPage/Header.js
@@ -18,6 +18,7 @@ const Wrapper = styled.header`
 const StyledLogoWrapper = styled.div`
   height: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 
@@ -35,12 +36,33 @@ const StyledLogo = styled(Logo)`
   height: 100px;
 `;
 
+const StyledTitle = styled.div`
+  text-align: center;
+  margin-top: 30px;
+`
+
+const StyledFlightboxLabel = styled.div`
+  font-size: 1.8rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: ${props => props.theme.colors.main};
+`
+
+const StyledAerodromeName = styled.div`
+  font-size: 1.1rem;
+  color: #666;
+`
+
 const Header = () => (
   <Wrapper>
     <StyledLogoWrapper>
       <StyledLink to="/">
         <StyledLogo className="logo"/>
       </StyledLink>
+      <StyledTitle>
+        <StyledFlightboxLabel>Flightbox</StyledFlightboxLabel>
+        <StyledAerodromeName>{__CONF__.aerodrome.name}</StyledAerodromeName>
+      </StyledTitle>
     </StyledLogoWrapper>
   </Wrapper>
 );

--- a/src/components/StartPage/Header.js
+++ b/src/components/StartPage/Header.js
@@ -5,12 +5,14 @@ import LoginInfo from './LoginInfo';
 import Logo from '../Logo';
 
 const StyledHeader = styled.header`
-  position: absolute;
-  height: 25%;
+  position: fixed;
   width: 100%;
+  top: 0;
+  left: 0;
   background-color: ${props => props.theme.colors.background};
   padding: 10px;
   box-sizing: border-box;
+  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
 `;
 
 const StyledLogoWrapper = styled.div`
@@ -24,8 +26,22 @@ const StyledLoginInfo = styled(LoginInfo)`
 `;
 
 const StyledLogo = styled(Logo)`
-  height: ${props => props.theme.logoSize || 85}%;
+  height: 50px;
 `;
+
+const StyledTitle = styled.div`
+  margin-left: 1.5rem;
+`
+
+const StyledFlightboxLabel = styled.div`
+  font-size: 1.2rem;
+  margin-bottom: 0.3rem;
+  color: ${props => props.theme.colors.main};
+`
+
+const StyledAerodromeName = styled.div`
+  color: #666;
+`
 
 class Header extends React.PureComponent {
 
@@ -36,6 +52,10 @@ class Header extends React.PureComponent {
         <StyledLoginInfo logout={props.logout} auth={props.auth} showLogin={props.showLogin}/>
         <StyledLogoWrapper>
           <StyledLogo/>
+          <StyledTitle>
+            <StyledFlightboxLabel>Flightbox</StyledFlightboxLabel>
+            <StyledAerodromeName>{__CONF__.aerodrome.name}</StyledAerodromeName>
+          </StyledTitle>
         </StyledLogoWrapper>
       </StyledHeader>
     );

--- a/src/components/StartPage/Main.js
+++ b/src/components/StartPage/Main.js
@@ -6,9 +6,7 @@ import Hints from './Hints';
 import EntryPoints from './EntryPoints';
 
 const Wrapper = styled.div`
-  position: absolute;
-  top: 25%;
-  width: 100%;
+  padding-top: 100px;
 `;
 
 class Main extends React.PureComponent {

--- a/src/components/VerticalHeaderLayout/Content.js
+++ b/src/components/VerticalHeaderLayout/Content.js
@@ -3,8 +3,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  margin-left: 17%;
-  
+  margin-left: 120px;
+
   @media screen and (max-width: 768px) {
     margin-left: 0;
   }

--- a/src/components/VerticalHeaderLayout/Header.js
+++ b/src/components/VerticalHeaderLayout/Header.js
@@ -8,10 +8,11 @@ const Wrapper = styled.header`
   top: 0;
   left: 0;
   height: 100%;
-  width: 17%;
+  width: 120px;
   box-sizing: border-box;
   background-color: ${props => props.theme.colors.background};
   text-align: center;
+  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
 
   @media screen and (max-width: 768px) {
     display: none;
@@ -23,6 +24,26 @@ const StyledLogo = styled(Logo)`
   margin-top: 10px;
 `;
 
+const StyledTitle = styled.div`
+  text-align: center;
+  margin-top: 25px;
+  padding: 0 10px;
+`
+
+const StyledFlightboxLabel = styled.div`
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: ${props => props.theme.colors.main};
+  margin-bottom: 4px;
+`
+
+const StyledAerodromeName = styled.div`
+  font-size: 0.75rem;
+  color: #666;
+  line-height: 1.2;
+  word-break: break-word;
+`
+
 class Header extends React.PureComponent {
 
   render() {
@@ -31,6 +52,10 @@ class Header extends React.PureComponent {
         <Link to="/">
           <StyledLogo/>
         </Link>
+        <StyledTitle>
+          <StyledFlightboxLabel>Flightbox</StyledFlightboxLabel>
+          <StyledAerodromeName>{__CONF__.aerodrome.name}</StyledAerodromeName>
+        </StyledTitle>
       </Wrapper>
     );
   }

--- a/theme/lspv/index.js
+++ b/theme/lspv/index.js
@@ -3,7 +3,7 @@ const logo = require('./logo.gif');
 const theme = {
   colors: {
     main: '#1d77d7',
-    background: '#f6f6f6',
+    background: '#fafafa',
     danger: '#fa4214'
   },
   images: {

--- a/theme/lszm/index.js
+++ b/theme/lszm/index.js
@@ -3,7 +3,7 @@ const logo = require('./logo.png');
 const theme = {
   colors: {
     main: '#324158',
-    background: '#f6f6f6',
+    background: '#fafafa',
     danger: '#fa4214'
   },
   images: {

--- a/theme/lszo/index.js
+++ b/theme/lszo/index.js
@@ -3,7 +3,7 @@ const logo = require('./logo.svg');
 const theme = {
   colors: {
     main: '#19295d',
-    background: '#f6f6f6',
+    background: '#fafafa',
     danger: '#fa4214'
   },
   images: {

--- a/theme/lszt/index.js
+++ b/theme/lszt/index.js
@@ -3,7 +3,7 @@ const logo = require('./logo.png');
 const theme = {
   colors: {
     main: '#003863',
-    background: '#f6f6f6',
+    background: '#fafafa',
     danger: '#e00f00'
   },
   images: {


### PR DESCRIPTION
- Headers are now smaller and with a drop shadow
- Grey background a bit lighter
- Added "Flightbox" label and the aerodrome name to the headers and also to the login page
- Start page tiles now without rounded corners and with drop shadow (similar to the movement list rectangular list items and shadows)